### PR TITLE
test: adding configured socket-addr to prover

### DIFF
--- a/crates/agglayer-prover/src/lib.rs
+++ b/crates/agglayer-prover/src/lib.rs
@@ -2,6 +2,10 @@ use std::{path::PathBuf, sync::Arc};
 
 use prover_engine::ProverEngine;
 use sp1_sdk::HashableKey;
+#[cfg(feature = "testutils")]
+pub use testutils::start_prover;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
 
 #[cfg(feature = "testutils")]
 pub mod fake;
@@ -75,14 +79,11 @@ mod testutils {
             .config(config)
             .cancellation_token(global_cancellation_token)
             .program(program)
+            .set_rpc_socket_addr(config.grpc_endpoint)
+            .set_metric_socket_addr(config.telemetry.addr)
             .start()
             .await
             .unwrap();
         prover.await_shutdown().await;
     }
 }
-
-#[cfg(feature = "testutils")]
-pub use testutils::start_prover;
-use tokio_util::sync::CancellationToken;
-use tracing::info;


### PR DESCRIPTION
# Description

This PR updates the test helper function to use the configured socket addr.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
