### PR TITLE
chore: revert "test: adding configured socket-addr to prover"

### DIFF
--- a/crates/agglayer-prover/src/lib.rs
+++ b/crates/agglayer-prover/src/lib.rs
@@ -2,10 +2,6 @@ use std::{path::PathBuf, sync::Arc};
 
 use prover_engine::ProverEngine;
 use sp1_sdk::HashableKey;
-#[cfg(feature = "testutils")]
-pub use testutils::start_prover;
-use tokio_util::sync::CancellationToken;
-use tracing::info;
 
 #[cfg(feature = "testutils")]
 pub mod fake;
@@ -79,11 +75,14 @@ mod testutils {
             .config(config)
             .cancellation_token(global_cancellation_token)
             .program(program)
-            .set_rpc_socket_addr(config.grpc_endpoint)
-            .set_metric_socket_addr(config.telemetry.addr)
             .start()
             .await
             .unwrap();
         prover.await_shutdown().await;
     }
 }
+
+#[cfg(feature = "testutils")]
+pub use testutils::start_prover;
+use tokio_util::sync::CancellationToken;
+use tracing::info;


### PR DESCRIPTION
This PR reverts agglayer/provers#30