### PR TITLE
fix: adding ready checks on primary prover

### DIFF
--- a/crates/prover-executor/src/lib.rs
+++ b/crates/prover-executor/src/lib.rs
@@ -165,8 +165,8 @@ impl Service<Request> for Executor {
     type Error = Error;
     type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
-    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.primary.poll_ready(cx)
     }
 
     fn call(&mut self, req: Request) -> Self::Future {


### PR DESCRIPTION
# Description

This PR is fixing a panic when trying to execute primary prover that isn't ready.
It adds the needed pre-check on the readiness of the service before calling it.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
