### PR TITLE
feat: aggchain contracts client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,10 +51,14 @@ dependencies = [
 name = "aggchain-proof-contracts"
 version = "0.1.0"
 dependencies = [
+ "aggchain-proof-core",
  "alloy",
  "anyhow",
- "futures",
+ "async-trait",
+ "jsonrpsee",
  "prover-alloy",
+ "prover-utils",
+ "serde",
  "serde_json",
  "thiserror 2.0.11",
  "tokio",

--- a/crates/aggchain-proof-builder/src/config.rs
+++ b/crates/aggchain-proof-builder/src/config.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use aggchain_proof_contracts::config::AggchainProofContractsConfig;
 use prover_config::ProverType;
 use serde::{Deserialize, Serialize};
 use url::Url;
@@ -9,12 +10,16 @@ use url::Url;
 #[serde(rename_all = "kebab-case")]
 pub struct AggchainProofBuilderConfig {
     /// JSON-RPC endpoint of the l1 node.
-    #[serde(default = "prover_alloy::default_l1_url")]
+    #[serde(default = "prover_alloy::default_l1_node_url")]
     pub l1_rpc_endpoint: Url,
 
+    /// JSON-RPC endpoint of the l2 execution node.
+    #[serde(default = "prover_alloy::default_l2_execution_layer_url")]
+    pub l2_el_rpc_endpoint: Url,
+
     /// JSON-RPC endpoint of the l2 rollup node.
-    #[serde(default = "prover_alloy::default_l2_url")]
-    pub l2_rpc_endpoint: Url,
+    #[serde(default = "prover_alloy::default_l2_consensus_layer_url")]
+    pub l2_cl_rpc_endpoint: Url,
 
     /// ID of the network for which the proof is generated (rollup id).
     pub network_id: u32,
@@ -28,17 +33,23 @@ pub struct AggchainProofBuilderConfig {
     /// Aggchain proof generation timeout in seconds.
     #[serde(default = "default_aggchain_prover_timeout")]
     pub proving_timeout: Duration,
+
+    /// Contract configuration
+    #[serde(default)]
+    pub contracts: AggchainProofContractsConfig,
 }
 
 impl Default for AggchainProofBuilderConfig {
     fn default() -> Self {
         AggchainProofBuilderConfig {
-            l1_rpc_endpoint: prover_alloy::default_l1_url(),
-            l2_rpc_endpoint: prover_alloy::default_l2_url(),
+            l1_rpc_endpoint: prover_alloy::default_l1_node_url(),
+            l2_el_rpc_endpoint: prover_alloy::default_l2_execution_layer_url(),
+            l2_cl_rpc_endpoint: prover_alloy::default_l2_consensus_layer_url(),
             network_id: 0,
             proving_timeout: default_aggchain_prover_timeout(),
             primary_prover: ProverType::NetworkProver(prover_config::NetworkProverConfig::default()),
             fallback_prover: None,
+            contracts: AggchainProofContractsConfig::default(),
         }
     }
 }

--- a/crates/aggchain-proof-builder/src/config.rs
+++ b/crates/aggchain-proof-builder/src/config.rs
@@ -15,11 +15,11 @@ pub struct AggchainProofBuilderConfig {
 
     /// JSON-RPC endpoint of the l2 execution node.
     #[serde(default = "prover_alloy::default_l2_execution_layer_url")]
-    pub l2_el_rpc_endpoint: Url,
+    pub l2_execution_layer_rpc_endpoint: Url,
 
     /// JSON-RPC endpoint of the l2 rollup node.
     #[serde(default = "prover_alloy::default_l2_consensus_layer_url")]
-    pub l2_cl_rpc_endpoint: Url,
+    pub l2_consensus_layer_rpc_endpoint: Url,
 
     /// ID of the network for which the proof is generated (rollup id).
     pub network_id: u32,
@@ -43,8 +43,8 @@ impl Default for AggchainProofBuilderConfig {
     fn default() -> Self {
         AggchainProofBuilderConfig {
             l1_rpc_endpoint: prover_alloy::default_l1_node_url(),
-            l2_el_rpc_endpoint: prover_alloy::default_l2_execution_layer_url(),
-            l2_cl_rpc_endpoint: prover_alloy::default_l2_consensus_layer_url(),
+            l2_execution_layer_rpc_endpoint: prover_alloy::default_l2_execution_layer_url(),
+            l2_consensus_layer_rpc_endpoint: prover_alloy::default_l2_consensus_layer_url(),
             network_id: 0,
             proving_timeout: default_aggchain_prover_timeout(),
             primary_prover: ProverType::NetworkProver(prover_config::NetworkProverConfig::default()),

--- a/crates/aggchain-proof-builder/src/config.rs
+++ b/crates/aggchain-proof-builder/src/config.rs
@@ -3,24 +3,11 @@ use std::time::Duration;
 use aggchain_proof_contracts::config::AggchainProofContractsConfig;
 use prover_config::ProverType;
 use serde::{Deserialize, Serialize};
-use url::Url;
 
 /// The Aggchain proof builder configuration
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "kebab-case")]
 pub struct AggchainProofBuilderConfig {
-    /// JSON-RPC endpoint of the l1 node.
-    #[serde(default = "prover_alloy::default_l1_node_url")]
-    pub l1_rpc_endpoint: Url,
-
-    /// JSON-RPC endpoint of the l2 execution node.
-    #[serde(default = "prover_alloy::default_l2_execution_layer_url")]
-    pub l2_execution_layer_rpc_endpoint: Url,
-
-    /// JSON-RPC endpoint of the l2 rollup node.
-    #[serde(default = "prover_alloy::default_l2_consensus_layer_url")]
-    pub l2_consensus_layer_rpc_endpoint: Url,
-
     /// ID of the network for which the proof is generated (rollup id).
     pub network_id: u32,
 
@@ -42,9 +29,6 @@ pub struct AggchainProofBuilderConfig {
 impl Default for AggchainProofBuilderConfig {
     fn default() -> Self {
         AggchainProofBuilderConfig {
-            l1_rpc_endpoint: prover_alloy::default_l1_node_url(),
-            l2_execution_layer_rpc_endpoint: prover_alloy::default_l2_execution_layer_url(),
-            l2_consensus_layer_rpc_endpoint: prover_alloy::default_l2_consensus_layer_url(),
             network_id: 0,
             proving_timeout: default_aggchain_prover_timeout(),
             primary_prover: ProverType::NetworkProver(prover_config::NetworkProverConfig::default()),

--- a/crates/aggchain-proof-builder/src/error.rs
+++ b/crates/aggchain-proof-builder/src/error.rs
@@ -6,6 +6,9 @@ pub enum Error {
     #[error("Failed to retrieve l2 chain data")]
     L2ChainDataRetrievalError(#[source] aggchain_proof_contracts::Error),
 
+    #[error("Failed to retrieve l1 chain data")]
+    L1ChainDataRetrievalError(#[source] aggchain_proof_contracts::Error),
+
     #[error("Prover executor returned an error")]
     ProverExecutorError(#[source] prover_executor::Error),
 

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -5,11 +5,15 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
-use aggchain_proof_contracts::AggchainProofContractsClient;
+use aggchain_proof_contracts::contracts::{
+    L1RollupConfigHashFetcher, L2LocalExitRootFetcher, L2OutputAtBlockFetcher,
+};
+use aggchain_proof_contracts::{AggchainContractsClient, AggchainContractsRpcClient};
 use aggchain_proof_core::proof::{AggchainProofWitness, InclusionProof, L1InfoTreeLeaf};
 use aggkit_prover_types::Hash;
 pub use error::Error;
 use futures::{future::BoxFuture, FutureExt};
+use prover_alloy::AlloyFillProvider;
 use prover_executor::Executor;
 use sp1_sdk::{SP1Proof, SP1ProofWithPublicValues, SP1VerifyingKey};
 use tower::buffer::Buffer;
@@ -70,10 +74,10 @@ pub struct AggchainProofBuilderResponse {
 /// This service is responsible for building an Aggchain proof.
 #[derive(Clone)]
 #[allow(unused)]
-pub struct AggchainProofBuilder {
+pub struct AggchainProofBuilder<ContractsClient> {
     /// Client for interacting with the smart contracts relevant for the
     /// aggchain prover.
-    contracts_client: Arc<AggchainProofContractsClient>,
+    contracts_client: Arc<ContractsClient>,
 
     /// Network id of the l2 chain for which the proof is generated.
     network_id: u32,
@@ -85,7 +89,7 @@ pub struct AggchainProofBuilder {
     aggchain_proof_vkey: SP1VerifyingKey,
 }
 
-impl AggchainProofBuilder {
+impl AggchainProofBuilder<AggchainContractsRpcClient<AlloyFillProvider>> {
     pub fn new(config: &AggchainProofBuilderConfig) -> Result<Self, Error> {
         let executor = tower::ServiceBuilder::new()
             .service(Executor::new(
@@ -100,21 +104,33 @@ impl AggchainProofBuilder {
 
         Ok(AggchainProofBuilder {
             contracts_client: Arc::new(
-                AggchainProofContractsClient::new(&config.l1_rpc_endpoint, &config.l2_rpc_endpoint)
-                    .map_err(Error::ContractsClientInitFailed)?,
+                AggchainContractsRpcClient::new(
+                    &config.l1_rpc_endpoint,
+                    &config.l2_el_rpc_endpoint,
+                    &config.l2_cl_rpc_endpoint,
+                    config.network_id,
+                    &config.contracts,
+                )
+                .map_err(Error::ContractsClientInitFailed)?,
             ),
             prover,
             network_id: config.network_id,
             aggchain_proof_vkey,
         })
     }
+}
 
+impl<ContractsClient> AggchainProofBuilder<ContractsClient> {
     /// Retrieve l1 and l2 public data needed for aggchain proof generation.
     /// Combine with the rest of the inputs to form an `AggchainProverInputs`.
     pub(crate) async fn retrieve_chain_data(
-        contracts_client: Arc<AggchainProofContractsClient>,
+        contracts_client: Arc<ContractsClient>,
         request: AggchainProofBuilderRequest,
-    ) -> Result<AggchainProverInputs, Error> {
+    ) -> Result<AggchainProverInputs, Error>
+    where
+        ContractsClient:
+            L2LocalExitRootFetcher + L2OutputAtBlockFetcher + L1RollupConfigHashFetcher,
+    {
         let _prev_local_exit_root = contracts_client
             .get_l2_local_exit_root(request.start_block - 1)
             .await
@@ -122,6 +138,21 @@ impl AggchainProofBuilder {
 
         let _new_local_exit_root = contracts_client
             .get_l2_local_exit_root(request.end_block)
+            .await
+            .map_err(Error::L2ChainDataRetrievalError)?;
+
+        let _l2_pre_root_output_at_block = contracts_client
+            .get_l2_output_at_block(request.start_block - 1)
+            .await
+            .map_err(Error::L2ChainDataRetrievalError)?;
+
+        let _claim_root_output_at_block = contracts_client
+            .get_l2_output_at_block(request.end_block)
+            .await
+            .map_err(Error::L2ChainDataRetrievalError)?;
+
+        let _rollup_config_hash = contracts_client
+            .get_rollup_config_hash()
             .await
             .map_err(Error::L2ChainDataRetrievalError)?;
 
@@ -137,7 +168,11 @@ impl AggchainProofBuilder {
     }
 }
 
-impl tower::Service<AggchainProofBuilderRequest> for AggchainProofBuilder {
+impl<ContractsClient> tower::Service<AggchainProofBuilderRequest>
+    for AggchainProofBuilder<ContractsClient>
+where
+    ContractsClient: AggchainContractsClient + Send + Sync + 'static,
+{
     type Response = AggchainProofBuilderResponse;
 
     type Error = Error;

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -154,7 +154,7 @@ impl<ContractsClient> AggchainProofBuilder<ContractsClient> {
         let _rollup_config_hash = contracts_client
             .get_rollup_config_hash()
             .await
-            .map_err(Error::L2ChainDataRetrievalError)?;
+            .map_err(Error::L1ChainDataRetrievalError)?;
 
         todo!()
     }

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -106,8 +106,8 @@ impl AggchainProofBuilder<AggchainContractsRpcClient<AlloyFillProvider>> {
             contracts_client: Arc::new(
                 AggchainContractsRpcClient::new(
                     &config.l1_rpc_endpoint,
-                    &config.l2_el_rpc_endpoint,
-                    &config.l2_cl_rpc_endpoint,
+                    &config.l2_execution_layer_rpc_endpoint,
+                    &config.l2_consensus_layer_rpc_endpoint,
                     config.network_id,
                     &config.contracts,
                 )

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -104,15 +104,9 @@ impl AggchainProofBuilder<AggchainContractsRpcClient<AlloyFillProvider>> {
 
         Ok(AggchainProofBuilder {
             contracts_client: Arc::new(
-                AggchainContractsRpcClient::new(
-                    &config.l1_rpc_endpoint,
-                    &config.l2_execution_layer_rpc_endpoint,
-                    &config.l2_consensus_layer_rpc_endpoint,
-                    config.network_id,
-                    &config.contracts,
-                )
-                .await
-                .map_err(Error::ContractsClientInitFailed)?,
+                AggchainContractsRpcClient::new(config.network_id, &config.contracts)
+                    .await
+                    .map_err(Error::ContractsClientInitFailed)?,
             ),
             prover,
             network_id: config.network_id,

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -90,7 +90,7 @@ pub struct AggchainProofBuilder<ContractsClient> {
 }
 
 impl AggchainProofBuilder<AggchainContractsRpcClient<AlloyFillProvider>> {
-    pub fn new(config: &AggchainProofBuilderConfig) -> Result<Self, Error> {
+    pub async fn new(config: &AggchainProofBuilderConfig) -> Result<Self, Error> {
         let executor = tower::ServiceBuilder::new()
             .service(Executor::new(
                 &config.primary_prover,
@@ -111,6 +111,7 @@ impl AggchainProofBuilder<AggchainContractsRpcClient<AlloyFillProvider>> {
                     config.network_id,
                     &config.contracts,
                 )
+                .await
                 .map_err(Error::ContractsClientInitFailed)?,
             ),
             prover,

--- a/crates/aggchain-proof-contracts/Cargo.toml
+++ b/crates/aggchain-proof-contracts/Cargo.toml
@@ -7,14 +7,18 @@ license.workspace = true
 [dependencies]
 alloy.workspace = true
 anyhow.workspace = true
-futures.workspace = true
+async-trait.workspace = true
+jsonrpsee.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 url.workspace = true
 
+aggchain-proof-core.workspace = true
 prover-alloy.workspace = true
+prover-utils.workspace = true
 
 [lints]
 workspace = true

--- a/crates/aggchain-proof-contracts/contracts/aggchain-fep.json
+++ b/crates/aggchain-proof-contracts/contracts/aggchain-fep.json
@@ -1,0 +1,1147 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "AggchainFEP",
+  "sourceName": "contracts/v2/aggchains/AggchainFEP.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IPolygonZkEVMGlobalExitRootV2",
+          "name": "_globalExitRootManager",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20Upgradeable",
+          "name": "_pol",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IPolygonZkEVMBridgeV2",
+          "name": "_bridgeAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "contract PolygonRollupManager",
+          "name": "_rollupManager",
+          "type": "address"
+        },
+        {
+          "internalType": "contract AggLayerGateway",
+          "name": "_aggLayerGateway",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AggchainVKeyNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BatchAlreadyVerified",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BatchNotSequencedOrNotSequenceEnd",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ExceedMaxVerifyBatches",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalAccInputHashDoesNotMatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalNumBatchBelowLastVerifiedBatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalNumBatchDoesNotMatchPendingState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalPendingStateNumInvalid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ForceBatchNotAllowed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ForceBatchTimeoutNotExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ForceBatchesAlreadyActive",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ForceBatchesDecentralized",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ForceBatchesNotAllowedOnEmergencyState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ForceBatchesOverflow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ForcedDataDoesNotMatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "GasTokenNetworkMustBeZeroOnEther",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "GlobalExitRootNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "HaltTimeoutNotExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "HaltTimeoutNotExpiredAfterEmergencyState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "HugeTokenMetadataNotSupported",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InitNumBatchAboveLastVerifiedBatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InitNumBatchDoesNotMatchPendingState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InitSequencedBatchDoesNotMatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidAggchainVKey",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidInitializeFunction",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidInitializeTransaction",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidInitializer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidProof",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRangeBatchTimeTarget",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRangeForceBatchTimeout",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRangeMultiplierBatchFee",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "L1InfoTreeLeafCountInvalid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MaxTimestampSequenceInvalid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NewAccInputHashDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NewPendingStateTimeoutMustBeLower",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NewStateRootNotInsidePrime",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NewTrustedAggregatorTimeoutMustBeLower",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotEnoughMaticAmount",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotEnoughPOLAmount",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OldAccInputHashDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OldStateRootDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyAdmin",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyPendingAdmin",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyPendingVKeyManager",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyRollupManager",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyTrustedAggregator",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyTrustedSequencer",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyVKeyManager",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OwnedAggchainVKeyAlreadyAdded",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OwnedAggchainVKeyLengthMismatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OwnedAggchainVKeyNotFound",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PendingStateDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PendingStateInvalid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PendingStateNotConsolidable",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PendingStateTimeoutExceedHaltAggregationTimeout",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SequenceZeroBatches",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SequencedTimestampBelowForcedTimestamp",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SequencedTimestampInvalid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StoredRootMustBeDifferentThanNewRoot",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TransactionsLengthAboveMax",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TrustedAggregatorTimeoutExceedHaltAggregationTimeout",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TrustedAggregatorTimeoutNotExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "UseDefaultGatewayAlreadySet",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newAdmin",
+          "type": "address"
+        }
+      ],
+      "name": "AcceptAdminRole",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newVKeyManager",
+          "type": "address"
+        }
+      ],
+      "name": "AcceptVKeyManagerRole",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes4",
+          "name": "selector",
+          "type": "bytes4"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "newAggchainVKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "AddAggchainVKey",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "initStateRoot",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "initTimestamp",
+          "type": "uint128"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint128",
+          "name": "initL2BlockNumber",
+          "type": "uint128"
+        }
+      ],
+      "name": "OnVerifyPessimistic",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newTrustedSequencer",
+          "type": "address"
+        }
+      ],
+      "name": "SetTrustedSequencer",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "newTrustedSequencerURL",
+          "type": "string"
+        }
+      ],
+      "name": "SetTrustedSequencerURL",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newPendingAdmin",
+          "type": "address"
+        }
+      ],
+      "name": "TransferAdminRole",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newVKeyManager",
+          "type": "address"
+        }
+      ],
+      "name": "TransferVKeyManagerRole",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bytes4",
+          "name": "selector",
+          "type": "bytes4"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "newAggchainVKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "UpdateAggchainVKey",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "useDefaultGateway",
+          "type": "bool"
+        }
+      ],
+      "name": "UpdateUseDefaultGatewayFlag",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "AGGCHAIN_TYPE",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "AGGCHAIN_TYPE_SELECTOR",
+      "outputs": [
+        {
+          "internalType": "bytes2",
+          "name": "",
+          "type": "bytes2"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "acceptAdminRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "acceptVKeyManagerRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "aggchainSelector",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newAggchainVKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "addOwnedAggchainVKey",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "admin",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "aggLayerGateway",
+      "outputs": [
+        {
+          "internalType": "contract IAggLayerGateway",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "aggregationVkey",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "bridgeAddress",
+      "outputs": [
+        {
+          "internalType": "contract IPolygonZkEVMBridgeV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "chainConfigHash",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "chainData",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "lastStateRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint128",
+          "name": "timestamp",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint128",
+          "name": "l2BlockNumber",
+          "type": "uint128"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "disableUseDefaultGatewayFlag",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "enableUseDefaultGatewayFlag",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "forceBatchAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "forceBatchTimeout",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "name": "forcedBatches",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "gasTokenAddress",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "gasTokenNetwork",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "customChainData",
+          "type": "bytes"
+        }
+      ],
+      "name": "getAggchainHash",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "aggchainSelector",
+          "type": "bytes4"
+        }
+      ],
+      "name": "getAggchainVKey",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "aggchainVKey",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "globalExitRootManager",
+      "outputs": [
+        {
+          "internalType": "contract IPolygonZkEVMGlobalExitRootV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "initializeBytesCustomChain",
+          "type": "bytes"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lastAccInputHash",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lastForceBatch",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lastForceBatchSequenced",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "networkName",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "customData",
+          "type": "bytes"
+        }
+      ],
+      "name": "onVerifyPessimistic",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "aggchainVKeySelector",
+          "type": "bytes4"
+        }
+      ],
+      "name": "ownedAggchainVKeys",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "ownedAggchainVKey",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pendingAdmin",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pendingVKeyManager",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pol",
+      "outputs": [
+        {
+          "internalType": "contract IERC20Upgradeable",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rangeVkeyCommitment",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rollupManager",
+      "outputs": [
+        {
+          "internalType": "contract PolygonRollupManager",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newTrustedSequencer",
+          "type": "address"
+        }
+      ],
+      "name": "setTrustedSequencer",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "string",
+          "name": "newTrustedSequencerURL",
+          "type": "string"
+        }
+      ],
+      "name": "setTrustedSequencerURL",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newPendingAdmin",
+          "type": "address"
+        }
+      ],
+      "name": "transferAdminRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "newVKeyManager",
+          "type": "address"
+        }
+      ],
+      "name": "transferVKeyManagerRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "trustedSequencer",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "trustedSequencerURL",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes",
+          "name": "customInitializeData",
+          "type": "bytes"
+        }
+      ],
+      "name": "updateCustomInitializeData",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "aggchainSelector",
+          "type": "bytes4"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "updatedAggchainVKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "updateOwnedAggchainVKey",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "useDefaultGateway",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "vKeyManager",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x610120604052348015610010575f5ffd5b506040516126ea3803806126ea83398101604081905261002f91610153565b6001600160a01b0380861660a05280851660805280841660c052821660e05284848484848484848461005f61007f565b505050506001600160a01b031661010052506101c4975050505050505050565b5f54610100900460ff16156100ea5760405162461bcd60e51b815260206004820152602760248201527f496e697469616c697a61626c653a20636f6e747261637420697320696e697469604482015266616c697a696e6760c81b606482015260840160405180910390fd5b5f5460ff908116101561013a575f805460ff191660ff9081179091556040519081527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b565b6001600160a01b0381168114610150575f5ffd5b50565b5f5f5f5f5f60a08688031215610167575f5ffd5b85516101728161013c565b60208701519095506101838161013c565b60408701519094506101948161013c565b60608701519093506101a58161013c565b60808701519092506101b68161013c565b809150509295509295909350565b60805160a05160c05160e051610100516124d46102165f395f81816105c501526108b901525f81816104c501528181610d1a015261171901525f61059e01525f61068c01525f6106db01526124d45ff3fe608060405234801561000f575f5ffd5b50600436106102e3575f3560e01c80638501818211610187578063cfa8ed47116100dd578063e59f69c211610093578063effb84791161006e578063effb84791461075a578063f851a44014610779578063ff9040791461079e575f5ffd5b8063e59f69c2146106fd578063e631476c1461073e578063e7a7ed0214610746575f5ffd5b8063dc8c4249116100c3578063dc8c4249146106ae578063e279984e146106b6578063e46761c4146106d6575f5ffd5b8063cfa8ed4714610667578063d02103ca14610687575f5ffd5b8063ada8f9191161013d578063c32e4e3e11610118578063c32e4e3e14610623578063c754c7ed1461062c578063c89e42df14610654575f5ffd5b8063ada8f919146105e7578063b7fd13ce146105fa578063bfb193b614610603575f5ffd5b80639ee4afa31161016d5780639ee4afa314610586578063a3c573eb14610599578063ab0475cf146105c0575f5ffd5b8063850181821461056b5780638c3d73011461057e575f5ffd5b8063439fab911161023c5780636b8616ce116101f25780636ff512cc116101cd5780636ff512cc1461053257806371257022146105455780637e005eb214610558575f5ffd5b80636b8616ce146105025780636e05d2cd146105215780636e7fbce91461052a575f5ffd5b806349b7b8021161022257806349b7b802146104c0578063542028d5146104e75780636a55f66c146104ef575f5ffd5b8063439fab91146104745780634560526714610487575f5ffd5b80632c111c061161029c5780633c351e10116102775780633c351e10146103c05780633cbc795b146103e05780633f17f31b1461041d575f5ffd5b80632c111c0614610385578063314eb17b146103a5578063368c822c146103b8575f5ffd5b806319451a8f116102cc57806319451a8f1461032257806326782247146103375780632b31841e1461037c575f5ffd5b806301fcf6a0146102e7578063107bf28c1461030d575b5f5ffd5b6102fa6102f5366004611cd6565b6107d3565b6040519081526020015b60405180910390f35b61031561093d565b6040516103049190611cf6565b610335610330366004611d49565b6109c9565b005b6001546103579073ffffffffffffffffffffffffffffffffffffffff1681565b60405173ffffffffffffffffffffffffffffffffffffffff9091168152602001610304565b6102fa60735481565b6008546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6103356103b3366004611d49565b610b2a565b610335610c4b565b6009546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6009546104089074010000000000000000000000000000000000000000900463ffffffff1681565b60405163ffffffff9091168152602001610304565b6104437e0100000000000000000000000000000000000000000000000000000000000081565b6040517fffff0000000000000000000000000000000000000000000000000000000000009091168152602001610304565b610335610482366004611d71565b610d18565b6007546104a79068010000000000000000900467ffffffffffffffff1681565b60405167ffffffffffffffff9091168152602001610304565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b6103156112ce565b6102fa6104fd366004611ea1565b6112db565b6102fa610510366004611eee565b60066020525f908152604090205481565b6102fa60055481565b610408600181565b610335610540366004611f44565b61140c565b610335610553366004611f7d565b6114dc565b610335610566366004611d71565b61150e565b610335610579366004611f44565b611586565b61033561164a565b610335610594366004611ea1565b611717565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b6103356105f5366004611f44565b6118b7565b6102fa60725481565b603d546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6102fa60715481565b6007546104a790700100000000000000000000000000000000900467ffffffffffffffff1681565b610335610662366004612031565b611980565b6002546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b610335611a12565b603c546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b61071061070b366004612063565b611b30565b604080519384526fffffffffffffffffffffffffffffffff9283166020850152911690820152606001610304565b610335611b86565b6007546104a79067ffffffffffffffff1681565b6102fa610768366004611cd6565b603e6020525f908152604090205481565b5f546103579062010000900473ffffffffffffffffffffffffffffffffffffffff1681565b603d546107c39074010000000000000000000000000000000000000000900460ff1681565b6040519015158152602001610304565b603d545f9074010000000000000000000000000000000000000000900460ff161515810361086957507fffffffff0000000000000000000000000000000000000000000000000000000081165f908152603e602052604090205480610864576040517f925e5a3a00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b919050565b6040517f6cabfdab0000000000000000000000000000000000000000000000000000000081527fffffffff00000000000000000000000000000000000000000000000000000000831660048201527f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1690636cabfdab90602401602060405180830381865afa158015610913573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190610937919061207a565b92915050565b6004805461094a90612091565b80601f016020809104026020016040519081016040528092919081815260200182805461097690612091565b80156109c15780601f10610998576101008083540402835291602001916109c1565b820191905f5260205f20905b8154815290600101906020018083116109a457829003601f168201915b505050505081565b603c5473ffffffffffffffffffffffffffffffffffffffff163314610a1a576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b80610a51576040517f4aac8b8800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7fffffffff0000000000000000000000000000000000000000000000000000000082165f908152603e602052604090205415610ab9576040517fe3cc761000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7fffffffff0000000000000000000000000000000000000000000000000000000082165f818152603e6020908152604091829020849055815192835282018390527f6cd6ce07b60b06519523b9a97add34c2dcaa32dad22d44eb738554d81dfe2a7991015b60405180910390a15050565b603c5473ffffffffffffffffffffffffffffffffffffffff163314610b7b576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7fffffffff0000000000000000000000000000000000000000000000000000000082165f908152603e6020526040902054610be2576040517ff360deaf00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7fffffffff0000000000000000000000000000000000000000000000000000000082165f818152603e6020908152604091829020849055815192835282018390527f2ae81c794f274593f3cd22db9ad3af161ff9d93d15922b35629a6ffd9be7243f9101610b1e565b603d5473ffffffffffffffffffffffffffffffffffffffff163314610c9c576040517f05882cf000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d54603c80547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff90921691821790556040519081527f75ccbacededf0b9fc9371bb4cf651be4f96efab2c519a529cfd90e14c9d49ad2906020015b60405180910390a1565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff163314610d87576040517fb9b3a2c800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f805460ff16907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00815c168217905d505f54600290610100900460ff16158015610dd757505f5460ff8083169116105b610e67576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602e60248201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160448201527f647920696e697469616c697a6564000000000000000000000000000000000000606482015260840160405180910390fd5b5f80547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00001660ff80841691909117610100178255815c1690036110c7575f5f5f5f5f5f5f5f5f5f5f5f8e8e810190610ebf919061210a565b9b509b509b509b509b509b509b509b509b509b509b509b508b5f60026101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508a60025f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508960095f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508860039081610fa69190612247565b506004610fb38982612247565b50607196909655607294909455607392909255603c805473ffffffffffffffffffffffffffffffffffffffff9095167fffffffffffffffffffffffff000000000000000000000000000000000000000090951694909417909355604080516060810182529384526fffffffffffffffffffffffffffffffff91821660208501908152928216908401908152607480546001810182555f91909152935160029094027f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef813810194909455915191518116700100000000000000000000000000000000029116177f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef814909101555061122d9350505050565b60ff5f5c166001036111fb575f8080808080806110e6898b018b61235e565b607196909655607294909455607392909255603c805473ffffffffffffffffffffffffffffffffffffffff9095167fffffffffffffffffffffffff000000000000000000000000000000000000000090951694909417909355604080516060810182529384526fffffffffffffffffffffffffffffffff91821660208501908152928216908401908152607480546001810182555f91909152935160029094027f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef813810194909455915191518116700100000000000000000000000000000000029116177f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef814909101555061122d95505050505050565b6040517fadc06ae700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d80547fffffffffffffffffffffff00ffffffffffffffffffffffffffffffffffffffff16740100000000000000000000000000000000000000001790555f80547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff16905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a1505050565b6003805461094a90612091565b5f5f5f5f5f5f868060200190518101906112f591906123cb565b6072546073546071546040805160208082018a9052818301899052606082018890526080820187905260a082019590955260c081019390935260e080840192909252805180840390920182526101009092019091528051910120949950929750909550935091507c01000000000000000000000000000000000000000000000000000000007fffff00000000000000000000000000000000000000000000000000000000000087161760016113a9826107d3565b60405160e09290921b7fffffffff0000000000000000000000000000000000000000000000000000000016602083015260248201526044810183905260640160405160208183030381529060405280519060200120975050505050505050919050565b5f5462010000900473ffffffffffffffffffffffffffffffffffffffff163314611462576040517f4755657900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b600280547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83169081179091556040519081527ff54144f9611984021529f814a1cb6a41e22c58351510a0d9f7e822618abb9cc0906020015b60405180910390a150565b6040517ff57ac68300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f5462010000900473ffffffffffffffffffffffffffffffffffffffff163314611564576040517f4755657900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f808061157384860186612434565b6071929092556072556073555050505050565b603c5473ffffffffffffffffffffffffffffffffffffffff1633146115d7576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d80547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83169081179091556040519081527ffa4ea207951b027c94aa15f12ca5d0f4ca0543beb8426209ac79b49d2fc46b10906020016114d1565b60015473ffffffffffffffffffffffffffffffffffffffff16331461169b576040517fd1ec4b2300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6001545f80547fffffffffffffffffffff0000000000000000000000000000000000000000ffff1673ffffffffffffffffffffffffffffffffffffffff9092166201000081029290921790556040519081527f056dc487bbf0795d0bbb1b4f0af523a855503cff740bfb4d5475f7a90c091e8e90602001610d0e565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff163314611786576040517fb9b3a2c800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f5f5f8380602001905181019061179d919061245d565b604080516060810182528481526fffffffffffffffffffffffffffffffff80851660208301908152818516838501908152607480546001810182555f91909152935160029094027f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef813810194909455905190518216700100000000000000000000000000000000029116177f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef814909101555192955090935091507fee142fa601a9012bb8f08c7f3c83d2b120f9f912cd921fe80291200cbb9e46b0906118a9908590859085909283526fffffffffffffffffffffffffffffffff918216602084015216604082015260600190565b60405180910390a150505050565b5f5462010000900473ffffffffffffffffffffffffffffffffffffffff16331461190d576040517f4755657900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b600180547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83169081179091556040519081527fa5b56b7906fd0a20e3f35120dd8343db1e12e037a6c90111c7e42885e82a1ce6906020016114d1565b5f5462010000900473ffffffffffffffffffffffffffffffffffffffff1633146119d6576040517f4755657900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60036119e28282612247565b507f6b8f723a4c7a5335cafae8a598a0aa0301be1387c037dccc085b62add6448b20816040516114d19190611cf6565b603c5473ffffffffffffffffffffffffffffffffffffffff163314611a63576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d5474010000000000000000000000000000000000000000900460ff16611ab7576040517f6f318e4c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d80547fffffffffffffffffffffff00ffffffffffffffffffffffffffffffffffffffff16908190556040517fd4305f3587ac0e4b2b8b4e5b2072599efd931f81aba626cdbef4b040078b507091610d0e917401000000000000000000000000000000000000000090910460ff161515815260200190565b60748181548110611b3f575f80fd5b5f918252602090912060029091020180546001909101549091506fffffffffffffffffffffffffffffffff8082169170010000000000000000000000000000000090041683565b603c5473ffffffffffffffffffffffffffffffffffffffff163314611bd7576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d5474010000000000000000000000000000000000000000900460ff1615611c2c576040517f6f318e4c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d80547fffffffffffffffffffffff00ffffffffffffffffffffffffffffffffffffffff1674010000000000000000000000000000000000000000908117918290556040517fd4305f3587ac0e4b2b8b4e5b2072599efd931f81aba626cdbef4b040078b507092610d0e92900460ff161515815260200190565b80357fffffffff0000000000000000000000000000000000000000000000000000000081168114610864575f5ffd5b5f60208284031215611ce6575f5ffd5b611cef82611ca7565b9392505050565b602081525f82518060208401528060208501604085015e5f6040828501015260407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f83011684010191505092915050565b5f5f60408385031215611d5a575f5ffd5b611d6383611ca7565b946020939093013593505050565b5f5f60208385031215611d82575f5ffd5b823567ffffffffffffffff811115611d98575f5ffd5b8301601f81018513611da8575f5ffd5b803567ffffffffffffffff811115611dbe575f5ffd5b856020828401011115611dcf575f5ffd5b6020919091019590945092505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b5f5f67ffffffffffffffff841115611e2657611e26611ddf565b506040517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f85018116603f0116810181811067ffffffffffffffff82111715611e7357611e73611ddf565b604052838152905080828401851015611e8a575f5ffd5b838360208301375f60208583010152509392505050565b5f60208284031215611eb1575f5ffd5b813567ffffffffffffffff811115611ec7575f5ffd5b8201601f81018413611ed7575f5ffd5b611ee684823560208401611e0c565b949350505050565b5f60208284031215611efe575f5ffd5b813567ffffffffffffffff81168114611cef575f5ffd5b73ffffffffffffffffffffffffffffffffffffffff81168114611f36575f5ffd5b50565b803561086481611f15565b5f60208284031215611f54575f5ffd5b8135611cef81611f15565b5f82601f830112611f6e575f5ffd5b611cef83833560208501611e0c565b5f5f5f5f5f5f60c08789031215611f92575f5ffd5b8635611f9d81611f15565b95506020870135611fad81611f15565b9450604087013563ffffffff81168114611fc5575f5ffd5b93506060870135611fd581611f15565b9250608087013567ffffffffffffffff811115611ff0575f5ffd5b611ffc89828a01611f5f565b92505060a087013567ffffffffffffffff811115612018575f5ffd5b61202489828a01611f5f565b9150509295509295509295565b5f60208284031215612041575f5ffd5b813567ffffffffffffffff811115612057575f5ffd5b611ee684828501611f5f565b5f60208284031215612073575f5ffd5b5035919050565b5f6020828403121561208a575f5ffd5b5051919050565b600181811c908216806120a557607f821691505b6020821081036120dc577f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b50919050565b6fffffffffffffffffffffffffffffffff81168114611f36575f5ffd5b8035610864816120e2565b5f5f5f5f5f5f5f5f5f5f5f5f6101808d8f031215612126575f5ffd5b61212f8d611f39565b9b5061213d60208e01611f39565b9a5061214b60408e01611f39565b995067ffffffffffffffff60608e01351115612165575f5ffd5b6121758e60608f01358f01611f5f565b985067ffffffffffffffff60808e0135111561218f575f5ffd5b61219f8e60808f01358f01611f5f565b975060a08d0135965060c08d0135955060e08d013594506101008d013593506121cb6101208e016120ff565b92506121da6101408e016120ff565b91506121e96101608e01611f39565b90509295989b509295989b509295989b565b601f82111561224257805f5260205f20601f840160051c810160208510156122205750805b601f840160051c820191505b8181101561223f575f815560010161222c565b50505b505050565b815167ffffffffffffffff81111561226157612261611ddf565b6122758161226f8454612091565b846121fb565b6020601f8211600181146122c6575f83156122905750848201515b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600385901b1c1916600184901b17845561223f565b5f848152602081207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe08516915b8281101561231357878501518255602094850194600190920191016122f3565b508482101561234f57868401517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600387901b60f8161c191681555b50505050600190811b01905550565b5f5f5f5f5f5f5f60e0888a031215612374575f5ffd5b87359650602088013595506040880135945060608801359350608088013561239b816120e2565b925060a08801356123ab816120e2565b915060c08801356123bb81611f15565b8091505092959891949750929550565b5f5f5f5f5f60a086880312156123df575f5ffd5b85517fffff0000000000000000000000000000000000000000000000000000000000008116811461240e575f5ffd5b602087015160408801516060890151608090990151929a91995097965090945092505050565b5f5f5f60608486031215612446575f5ffd5b505081359360208301359350604090920135919050565b5f5f5f6060848603121561246f575f5ffd5b83516020850151909350612482816120e2565b6040850151909250612493816120e2565b80915050925092509256fea2646970667358221220b4377b0c5297417844872850ccf0a126d87cdb1fd3d9fcff95ec9eadaa6ec9a164736f6c634300081c0033",
+  "deployedBytecode": "0x608060405234801561000f575f5ffd5b50600436106102e3575f3560e01c80638501818211610187578063cfa8ed47116100dd578063e59f69c211610093578063effb84791161006e578063effb84791461075a578063f851a44014610779578063ff9040791461079e575f5ffd5b8063e59f69c2146106fd578063e631476c1461073e578063e7a7ed0214610746575f5ffd5b8063dc8c4249116100c3578063dc8c4249146106ae578063e279984e146106b6578063e46761c4146106d6575f5ffd5b8063cfa8ed4714610667578063d02103ca14610687575f5ffd5b8063ada8f9191161013d578063c32e4e3e11610118578063c32e4e3e14610623578063c754c7ed1461062c578063c89e42df14610654575f5ffd5b8063ada8f919146105e7578063b7fd13ce146105fa578063bfb193b614610603575f5ffd5b80639ee4afa31161016d5780639ee4afa314610586578063a3c573eb14610599578063ab0475cf146105c0575f5ffd5b8063850181821461056b5780638c3d73011461057e575f5ffd5b8063439fab911161023c5780636b8616ce116101f25780636ff512cc116101cd5780636ff512cc1461053257806371257022146105455780637e005eb214610558575f5ffd5b80636b8616ce146105025780636e05d2cd146105215780636e7fbce91461052a575f5ffd5b806349b7b8021161022257806349b7b802146104c0578063542028d5146104e75780636a55f66c146104ef575f5ffd5b8063439fab91146104745780634560526714610487575f5ffd5b80632c111c061161029c5780633c351e10116102775780633c351e10146103c05780633cbc795b146103e05780633f17f31b1461041d575f5ffd5b80632c111c0614610385578063314eb17b146103a5578063368c822c146103b8575f5ffd5b806319451a8f116102cc57806319451a8f1461032257806326782247146103375780632b31841e1461037c575f5ffd5b806301fcf6a0146102e7578063107bf28c1461030d575b5f5ffd5b6102fa6102f5366004611cd6565b6107d3565b6040519081526020015b60405180910390f35b61031561093d565b6040516103049190611cf6565b610335610330366004611d49565b6109c9565b005b6001546103579073ffffffffffffffffffffffffffffffffffffffff1681565b60405173ffffffffffffffffffffffffffffffffffffffff9091168152602001610304565b6102fa60735481565b6008546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6103356103b3366004611d49565b610b2a565b610335610c4b565b6009546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6009546104089074010000000000000000000000000000000000000000900463ffffffff1681565b60405163ffffffff9091168152602001610304565b6104437e0100000000000000000000000000000000000000000000000000000000000081565b6040517fffff0000000000000000000000000000000000000000000000000000000000009091168152602001610304565b610335610482366004611d71565b610d18565b6007546104a79068010000000000000000900467ffffffffffffffff1681565b60405167ffffffffffffffff9091168152602001610304565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b6103156112ce565b6102fa6104fd366004611ea1565b6112db565b6102fa610510366004611eee565b60066020525f908152604090205481565b6102fa60055481565b610408600181565b610335610540366004611f44565b61140c565b610335610553366004611f7d565b6114dc565b610335610566366004611d71565b61150e565b610335610579366004611f44565b611586565b61033561164a565b610335610594366004611ea1565b611717565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b6103356105f5366004611f44565b6118b7565b6102fa60725481565b603d546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6102fa60715481565b6007546104a790700100000000000000000000000000000000900467ffffffffffffffff1681565b610335610662366004612031565b611980565b6002546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b610335611a12565b603c546103579073ffffffffffffffffffffffffffffffffffffffff1681565b6103577f000000000000000000000000000000000000000000000000000000000000000081565b61071061070b366004612063565b611b30565b604080519384526fffffffffffffffffffffffffffffffff9283166020850152911690820152606001610304565b610335611b86565b6007546104a79067ffffffffffffffff1681565b6102fa610768366004611cd6565b603e6020525f908152604090205481565b5f546103579062010000900473ffffffffffffffffffffffffffffffffffffffff1681565b603d546107c39074010000000000000000000000000000000000000000900460ff1681565b6040519015158152602001610304565b603d545f9074010000000000000000000000000000000000000000900460ff161515810361086957507fffffffff0000000000000000000000000000000000000000000000000000000081165f908152603e602052604090205480610864576040517f925e5a3a00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b919050565b6040517f6cabfdab0000000000000000000000000000000000000000000000000000000081527fffffffff00000000000000000000000000000000000000000000000000000000831660048201527f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1690636cabfdab90602401602060405180830381865afa158015610913573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190610937919061207a565b92915050565b6004805461094a90612091565b80601f016020809104026020016040519081016040528092919081815260200182805461097690612091565b80156109c15780601f10610998576101008083540402835291602001916109c1565b820191905f5260205f20905b8154815290600101906020018083116109a457829003601f168201915b505050505081565b603c5473ffffffffffffffffffffffffffffffffffffffff163314610a1a576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b80610a51576040517f4aac8b8800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7fffffffff0000000000000000000000000000000000000000000000000000000082165f908152603e602052604090205415610ab9576040517fe3cc761000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7fffffffff0000000000000000000000000000000000000000000000000000000082165f818152603e6020908152604091829020849055815192835282018390527f6cd6ce07b60b06519523b9a97add34c2dcaa32dad22d44eb738554d81dfe2a7991015b60405180910390a15050565b603c5473ffffffffffffffffffffffffffffffffffffffff163314610b7b576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7fffffffff0000000000000000000000000000000000000000000000000000000082165f908152603e6020526040902054610be2576040517ff360deaf00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b7fffffffff0000000000000000000000000000000000000000000000000000000082165f818152603e6020908152604091829020849055815192835282018390527f2ae81c794f274593f3cd22db9ad3af161ff9d93d15922b35629a6ffd9be7243f9101610b1e565b603d5473ffffffffffffffffffffffffffffffffffffffff163314610c9c576040517f05882cf000000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d54603c80547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff90921691821790556040519081527f75ccbacededf0b9fc9371bb4cf651be4f96efab2c519a529cfd90e14c9d49ad2906020015b60405180910390a1565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff163314610d87576040517fb9b3a2c800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f805460ff16907fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00815c168217905d505f54600290610100900460ff16158015610dd757505f5460ff8083169116105b610e67576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152602e60248201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160448201527f647920696e697469616c697a6564000000000000000000000000000000000000606482015260840160405180910390fd5b5f80547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00001660ff80841691909117610100178255815c1690036110c7575f5f5f5f5f5f5f5f5f5f5f5f8e8e810190610ebf919061210a565b9b509b509b509b509b509b509b509b509b509b509b509b508b5f60026101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508a60025f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508960095f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055508860039081610fa69190612247565b506004610fb38982612247565b50607196909655607294909455607392909255603c805473ffffffffffffffffffffffffffffffffffffffff9095167fffffffffffffffffffffffff000000000000000000000000000000000000000090951694909417909355604080516060810182529384526fffffffffffffffffffffffffffffffff91821660208501908152928216908401908152607480546001810182555f91909152935160029094027f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef813810194909455915191518116700100000000000000000000000000000000029116177f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef814909101555061122d9350505050565b60ff5f5c166001036111fb575f8080808080806110e6898b018b61235e565b607196909655607294909455607392909255603c805473ffffffffffffffffffffffffffffffffffffffff9095167fffffffffffffffffffffffff000000000000000000000000000000000000000090951694909417909355604080516060810182529384526fffffffffffffffffffffffffffffffff91821660208501908152928216908401908152607480546001810182555f91909152935160029094027f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef813810194909455915191518116700100000000000000000000000000000000029116177f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef814909101555061122d95505050505050565b6040517fadc06ae700000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d80547fffffffffffffffffffffff00ffffffffffffffffffffffffffffffffffffffff16740100000000000000000000000000000000000000001790555f80547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff16905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a1505050565b6003805461094a90612091565b5f5f5f5f5f5f868060200190518101906112f591906123cb565b6072546073546071546040805160208082018a9052818301899052606082018890526080820187905260a082019590955260c081019390935260e080840192909252805180840390920182526101009092019091528051910120949950929750909550935091507c01000000000000000000000000000000000000000000000000000000007fffff00000000000000000000000000000000000000000000000000000000000087161760016113a9826107d3565b60405160e09290921b7fffffffff0000000000000000000000000000000000000000000000000000000016602083015260248201526044810183905260640160405160208183030381529060405280519060200120975050505050505050919050565b5f5462010000900473ffffffffffffffffffffffffffffffffffffffff163314611462576040517f4755657900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b600280547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83169081179091556040519081527ff54144f9611984021529f814a1cb6a41e22c58351510a0d9f7e822618abb9cc0906020015b60405180910390a150565b6040517ff57ac68300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f5462010000900473ffffffffffffffffffffffffffffffffffffffff163314611564576040517f4755657900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f808061157384860186612434565b6071929092556072556073555050505050565b603c5473ffffffffffffffffffffffffffffffffffffffff1633146115d7576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d80547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83169081179091556040519081527ffa4ea207951b027c94aa15f12ca5d0f4ca0543beb8426209ac79b49d2fc46b10906020016114d1565b60015473ffffffffffffffffffffffffffffffffffffffff16331461169b576040517fd1ec4b2300000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b6001545f80547fffffffffffffffffffff0000000000000000000000000000000000000000ffff1673ffffffffffffffffffffffffffffffffffffffff9092166201000081029290921790556040519081527f056dc487bbf0795d0bbb1b4f0af523a855503cff740bfb4d5475f7a90c091e8e90602001610d0e565b7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff163314611786576040517fb9b3a2c800000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b5f5f5f8380602001905181019061179d919061245d565b604080516060810182528481526fffffffffffffffffffffffffffffffff80851660208301908152818516838501908152607480546001810182555f91909152935160029094027f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef813810194909455905190518216700100000000000000000000000000000000029116177f19a0b39aa25ac793b5f6e9a0534364cc0b3fd1ea9b651e79c7f50a59d48ef814909101555192955090935091507fee142fa601a9012bb8f08c7f3c83d2b120f9f912cd921fe80291200cbb9e46b0906118a9908590859085909283526fffffffffffffffffffffffffffffffff918216602084015216604082015260600190565b60405180910390a150505050565b5f5462010000900473ffffffffffffffffffffffffffffffffffffffff16331461190d576040517f4755657900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b600180547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83169081179091556040519081527fa5b56b7906fd0a20e3f35120dd8343db1e12e037a6c90111c7e42885e82a1ce6906020016114d1565b5f5462010000900473ffffffffffffffffffffffffffffffffffffffff1633146119d6576040517f4755657900000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60036119e28282612247565b507f6b8f723a4c7a5335cafae8a598a0aa0301be1387c037dccc085b62add6448b20816040516114d19190611cf6565b603c5473ffffffffffffffffffffffffffffffffffffffff163314611a63576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d5474010000000000000000000000000000000000000000900460ff16611ab7576040517f6f318e4c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d80547fffffffffffffffffffffff00ffffffffffffffffffffffffffffffffffffffff16908190556040517fd4305f3587ac0e4b2b8b4e5b2072599efd931f81aba626cdbef4b040078b507091610d0e917401000000000000000000000000000000000000000090910460ff161515815260200190565b60748181548110611b3f575f80fd5b5f918252602090912060029091020180546001909101549091506fffffffffffffffffffffffffffffffff8082169170010000000000000000000000000000000090041683565b603c5473ffffffffffffffffffffffffffffffffffffffff163314611bd7576040517fe4d753bd00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d5474010000000000000000000000000000000000000000900460ff1615611c2c576040517f6f318e4c00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b603d80547fffffffffffffffffffffff00ffffffffffffffffffffffffffffffffffffffff1674010000000000000000000000000000000000000000908117918290556040517fd4305f3587ac0e4b2b8b4e5b2072599efd931f81aba626cdbef4b040078b507092610d0e92900460ff161515815260200190565b80357fffffffff0000000000000000000000000000000000000000000000000000000081168114610864575f5ffd5b5f60208284031215611ce6575f5ffd5b611cef82611ca7565b9392505050565b602081525f82518060208401528060208501604085015e5f6040828501015260407fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f83011684010191505092915050565b5f5f60408385031215611d5a575f5ffd5b611d6383611ca7565b946020939093013593505050565b5f5f60208385031215611d82575f5ffd5b823567ffffffffffffffff811115611d98575f5ffd5b8301601f81018513611da8575f5ffd5b803567ffffffffffffffff811115611dbe575f5ffd5b856020828401011115611dcf575f5ffd5b6020919091019590945092505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b5f5f67ffffffffffffffff841115611e2657611e26611ddf565b506040517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0601f85018116603f0116810181811067ffffffffffffffff82111715611e7357611e73611ddf565b604052838152905080828401851015611e8a575f5ffd5b838360208301375f60208583010152509392505050565b5f60208284031215611eb1575f5ffd5b813567ffffffffffffffff811115611ec7575f5ffd5b8201601f81018413611ed7575f5ffd5b611ee684823560208401611e0c565b949350505050565b5f60208284031215611efe575f5ffd5b813567ffffffffffffffff81168114611cef575f5ffd5b73ffffffffffffffffffffffffffffffffffffffff81168114611f36575f5ffd5b50565b803561086481611f15565b5f60208284031215611f54575f5ffd5b8135611cef81611f15565b5f82601f830112611f6e575f5ffd5b611cef83833560208501611e0c565b5f5f5f5f5f5f60c08789031215611f92575f5ffd5b8635611f9d81611f15565b95506020870135611fad81611f15565b9450604087013563ffffffff81168114611fc5575f5ffd5b93506060870135611fd581611f15565b9250608087013567ffffffffffffffff811115611ff0575f5ffd5b611ffc89828a01611f5f565b92505060a087013567ffffffffffffffff811115612018575f5ffd5b61202489828a01611f5f565b9150509295509295509295565b5f60208284031215612041575f5ffd5b813567ffffffffffffffff811115612057575f5ffd5b611ee684828501611f5f565b5f60208284031215612073575f5ffd5b5035919050565b5f6020828403121561208a575f5ffd5b5051919050565b600181811c908216806120a557607f821691505b6020821081036120dc577f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b50919050565b6fffffffffffffffffffffffffffffffff81168114611f36575f5ffd5b8035610864816120e2565b5f5f5f5f5f5f5f5f5f5f5f5f6101808d8f031215612126575f5ffd5b61212f8d611f39565b9b5061213d60208e01611f39565b9a5061214b60408e01611f39565b995067ffffffffffffffff60608e01351115612165575f5ffd5b6121758e60608f01358f01611f5f565b985067ffffffffffffffff60808e0135111561218f575f5ffd5b61219f8e60808f01358f01611f5f565b975060a08d0135965060c08d0135955060e08d013594506101008d013593506121cb6101208e016120ff565b92506121da6101408e016120ff565b91506121e96101608e01611f39565b90509295989b509295989b509295989b565b601f82111561224257805f5260205f20601f840160051c810160208510156122205750805b601f840160051c820191505b8181101561223f575f815560010161222c565b50505b505050565b815167ffffffffffffffff81111561226157612261611ddf565b6122758161226f8454612091565b846121fb565b6020601f8211600181146122c6575f83156122905750848201515b7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600385901b1c1916600184901b17845561223f565b5f848152602081207fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe08516915b8281101561231357878501518255602094850194600190920191016122f3565b508482101561234f57868401517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff600387901b60f8161c191681555b50505050600190811b01905550565b5f5f5f5f5f5f5f60e0888a031215612374575f5ffd5b87359650602088013595506040880135945060608801359350608088013561239b816120e2565b925060a08801356123ab816120e2565b915060c08801356123bb81611f15565b8091505092959891949750929550565b5f5f5f5f5f60a086880312156123df575f5ffd5b85517fffff0000000000000000000000000000000000000000000000000000000000008116811461240e575f5ffd5b602087015160408801516060890151608090990151929a91995097965090945092505050565b5f5f5f60608486031215612446575f5ffd5b505081359360208301359350604090920135919050565b5f5f5f6060848603121561246f575f5ffd5b83516020850151909350612482816120e2565b6040850151909250612493816120e2565b80915050925092509256fea2646970667358221220b4377b0c5297417844872850ccf0a126d87cdb1fd3d9fcff95ec9eadaa6ec9a164736f6c634300081c0033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/crates/aggchain-proof-contracts/contracts/polygon-rollup-manager.json
+++ b/crates/aggchain-proof-contracts/contracts/polygon-rollup-manager.json
@@ -1,0 +1,1930 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "PolygonRollupManager",
+  "sourceName": "contracts/v2/PolygonRollupManager.sol",
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "contract IPolygonZkEVMGlobalExitRootV2",
+          "name": "_globalExitRootManager",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20Upgradeable",
+          "name": "_pol",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IPolygonZkEVMBridge",
+          "name": "_bridgeAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "contract AggLayerGateway",
+          "name": "_aggLayerGateway",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AccessControlOnlyCanRenounceRolesForSelf",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AddressDoNotHaveRequiredRole",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AllBatchesMustBeVerified",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AllSequencedMustBeVerified",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AllzkEVMSequencedBatchesMustBeVerified",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "BatchFeeOutOfRange",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "CannotUpdateWithUnconsolidatedPendingState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ChainIDAlreadyExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ChainIDOutOfRange",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "EmptyVerifySequencesData",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ExceedMaxVerifyBatches",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalNumBatchBelowLastVerifiedBatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalNumBatchDoesNotMatchPendingState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalNumSequenceBelowLastVerifiedSequence",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalNumSequenceDoesNotMatchPendingState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "FinalPendingStateNumInvalid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "HaltTimeoutNotExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InitBatchMustMatchCurrentForkID",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InitNumBatchAboveLastVerifiedBatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InitNumBatchDoesNotMatchPendingState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InitSequenceMustMatchCurrentForkID",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InitSequenceNumDoesNotMatchPendingState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidPessimisticProof",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidProof",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRangeBatchTimeTarget",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRangeMultiplierBatchFee",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRangeMultiplierZkGasPrice",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRangeSequenceTimeTarget",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRollup",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidRollupType",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidVerifierType",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "L1InfoTreeLeafCountInvalid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MustSequenceSomeBatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "MustSequenceSomeBlob",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NewAccInputHashDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NewPendingStateTimeoutMustBeLower",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NewStateRootNotInsidePrime",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NewTrustedAggregatorTimeoutMustBeLower",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NotAllowedAddress",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OldAccInputHashDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OldStateRootDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyEmergencyState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyNotEmergencyState",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyRollupAdmin",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "OnlyStateTransitionChains",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PendingStateDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PendingStateInvalid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PendingStateNotConsolidable",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PendingStateNumExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ReentrancyGuardReentrantCall",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RollbackBatchIsNotEndOfSequence",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RollbackBatchIsNotValid",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RollupAddressAlreadyExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RollupIDNotAscendingOrder",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RollupMustExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RollupTypeDoesNotExist",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "RollupTypeObsolete",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "SenderMustBeRollup",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StateTransitionChainsNotAllowed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StoredRootMustBeDifferentThanNewRoot",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "TrustedAggregatorTimeoutNotExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "UpdateNotCompatible",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "UpdateToOldRollupTypeID",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "UpdateToSameRollupTypeID",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "zkGasPriceOfRange",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "forkID",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rollupAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "chainID",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "enum IPolygonRollupManager.VerifierType",
+          "name": "rollupVerifierType",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "lastVerifiedBatchBeforeUpgrade",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "programVKey",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "initPessimisticRoot",
+          "type": "bytes32"
+        }
+      ],
+      "name": "AddExistingRollup",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "rollupTypeID",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "consensusImplementation",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "verifier",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "forkID",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "enum IPolygonRollupManager.VerifierType",
+          "name": "rollupVerifierType",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "genesis",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "description",
+          "type": "string"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "programVKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "AddNewRollupType",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "rollupTypeID",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "rollupAddress",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "chainID",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "gasTokenAddress",
+          "type": "address"
+        }
+      ],
+      "name": "CreateNewRollup",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EmergencyStateActivated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "EmergencyStateDeactivated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "rollupTypeID",
+          "type": "uint32"
+        }
+      ],
+      "name": "ObsoleteRollupType",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "lastBatchSequenced",
+          "type": "uint64"
+        }
+      ],
+      "name": "OnSequenceBatches",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint64",
+          "name": "targetBatch",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "accInputHashToRollback",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RollbackBatches",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newBatchFee",
+          "type": "uint256"
+        }
+      ],
+      "name": "SetBatchFee",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "newTrustedAggregator",
+          "type": "address"
+        }
+      ],
+      "name": "SetTrustedAggregator",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint32",
+          "name": "newRollupTypeID",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "lastVerifiedBatchBeforeUpgrade",
+          "type": "uint64"
+        }
+      ],
+      "name": "UpdateRollup",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "string",
+          "name": "rollupManagerVersion",
+          "type": "string"
+        }
+      ],
+      "name": "UpdateRollupManagerVersion",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "numBatch",
+          "type": "uint64"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "stateRoot",
+          "type": "bytes32"
+        },
+        {
+          "indexed": false,
+          "internalType": "bytes32",
+          "name": "exitRoot",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "aggregator",
+          "type": "address"
+        }
+      ],
+      "name": "VerifyBatchesTrustedAggregator",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "ROLLUP_MANAGER_VERSION",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "activateEmergencyState",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rollupAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "verifier",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "forkID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "chainID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "initRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "enum IPolygonRollupManager.VerifierType",
+          "name": "rollupVerifierType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "programVKey",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "initPessimisticRoot",
+          "type": "bytes32"
+        }
+      ],
+      "name": "addExistingRollup",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "consensusImplementation",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "verifier",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "forkID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "enum IPolygonRollupManager.VerifierType",
+          "name": "rollupVerifierType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "genesis",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "string",
+          "name": "description",
+          "type": "string"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "programVKey",
+          "type": "bytes32"
+        }
+      ],
+      "name": "addNewRollupType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "aggLayerGateway",
+      "outputs": [
+        {
+          "internalType": "contract AggLayerGateway",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "bridgeAddress",
+      "outputs": [
+        {
+          "internalType": "contract IPolygonZkEVMBridge",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "calculateRewardPerBatch",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "chainID",
+          "type": "uint64"
+        }
+      ],
+      "name": "chainIDToRollupID",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupTypeID",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint64",
+          "name": "chainID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "address",
+          "name": "admin",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "sequencer",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "gasTokenAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "string",
+          "name": "sequencerURL",
+          "type": "string"
+        },
+        {
+          "internalType": "string",
+          "name": "networkName",
+          "type": "string"
+        },
+        {
+          "internalType": "bytes",
+          "name": "initializeBytesCustomChain",
+          "type": "bytes"
+        }
+      ],
+      "name": "createNewRollup",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "deactivateEmergencyState",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getBatchFee",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getForcedBatchFee",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "l1InfoTreeRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newLocalExitRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newPessimisticRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "customChainData",
+          "type": "bytes"
+        }
+      ],
+      "name": "getInputPessimisticBytes",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint64",
+          "name": "initNumBatch",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "finalNewBatch",
+          "type": "uint64"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newLocalExitRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "oldStateRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newStateRoot",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getInputSnarkBytes",
+      "outputs": [
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        }
+      ],
+      "name": "getLastVerifiedBatch",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint64",
+          "name": "batchNum",
+          "type": "uint64"
+        }
+      ],
+      "name": "getRollupBatchNumToStateRoot",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getRollupExitRoot",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint64",
+          "name": "batchNum",
+          "type": "uint64"
+        }
+      ],
+      "name": "getRollupSequencedBatches",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "bytes32",
+              "name": "accInputHash",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "sequencedTimestamp",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "previousLastBatchSequenced",
+              "type": "uint64"
+            }
+          ],
+          "internalType": "struct LegacyZKEVMStateVariables.SequencedBatchData",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "globalExitRootManager",
+      "outputs": [
+        {
+          "internalType": "contract IPolygonZkEVMGlobalExitRootV2",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "isEmergencyState",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lastAggregationTimestamp",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lastDeactivatedEmergencyStateTimestamp",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupTypeID",
+          "type": "uint32"
+        }
+      ],
+      "name": "obsoleteRollupType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint64",
+          "name": "newSequencedBatches",
+          "type": "uint64"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newAccInputHash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "onSequenceBatches",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pol",
+      "outputs": [
+        {
+          "internalType": "contract IERC20Upgradeable",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IPolygonRollupBase",
+          "name": "rollupContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "targetBatch",
+          "type": "uint64"
+        }
+      ],
+      "name": "rollbackBatches",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "rollupAddress",
+          "type": "address"
+        }
+      ],
+      "name": "rollupAddressToID",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rollupCount",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        }
+      ],
+      "name": "rollupIDToRollupData",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "rollupContract",
+              "type": "address"
+            },
+            {
+              "internalType": "uint64",
+              "name": "chainID",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "verifier",
+              "type": "address"
+            },
+            {
+              "internalType": "uint64",
+              "name": "forkID",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "lastLocalExitRoot",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "lastBatchSequenced",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "lastVerifiedBatch",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "_legacyLastPendingState",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "_legacyLastPendingStateConsolidated",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "lastVerifiedBatchBeforeUpgrade",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "rollupTypeID",
+              "type": "uint64"
+            },
+            {
+              "internalType": "enum IPolygonRollupManager.VerifierType",
+              "name": "rollupVerifierType",
+              "type": "uint8"
+            }
+          ],
+          "internalType": "struct PolygonRollupManager.RollupDataReturn",
+          "name": "rollupData",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        }
+      ],
+      "name": "rollupIDToRollupDataDeserialized",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "rollupContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "chainID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "address",
+          "name": "verifier",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "forkID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "lastLocalExitRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "uint64",
+          "name": "lastBatchSequenced",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "lastVerifiedBatch",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "lastVerifiedBatchBeforeUpgrade",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "rollupTypeID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "enum IPolygonRollupManager.VerifierType",
+          "name": "rollupVerifierType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "lastPessimisticRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "programVKey",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        }
+      ],
+      "name": "rollupIDToRollupDataV2",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "rollupContract",
+              "type": "address"
+            },
+            {
+              "internalType": "uint64",
+              "name": "chainID",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "verifier",
+              "type": "address"
+            },
+            {
+              "internalType": "uint64",
+              "name": "forkID",
+              "type": "uint64"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "lastLocalExitRoot",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "uint64",
+              "name": "lastBatchSequenced",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "lastVerifiedBatch",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "lastVerifiedBatchBeforeUpgrade",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "rollupTypeID",
+              "type": "uint64"
+            },
+            {
+              "internalType": "enum IPolygonRollupManager.VerifierType",
+              "name": "rollupVerifierType",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "lastPessimisticRoot",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "programVKey",
+              "type": "bytes32"
+            }
+          ],
+          "internalType": "struct PolygonRollupManager.RollupDataReturnV2",
+          "name": "rollupData",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rollupTypeCount",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupTypeID",
+          "type": "uint32"
+        }
+      ],
+      "name": "rollupTypeMap",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "consensusImplementation",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "verifier",
+          "type": "address"
+        },
+        {
+          "internalType": "uint64",
+          "name": "forkID",
+          "type": "uint64"
+        },
+        {
+          "internalType": "enum IPolygonRollupManager.VerifierType",
+          "name": "rollupVerifierType",
+          "type": "uint8"
+        },
+        {
+          "internalType": "bool",
+          "name": "obsolete",
+          "type": "bool"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "genesis",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "programVKey",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "newBatchFee",
+          "type": "uint256"
+        }
+      ],
+      "name": "setBatchFee",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalSequencedBatches",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalVerifiedBatches",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "",
+          "type": "uint64"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract ITransparentUpgradeableProxy",
+          "name": "rollupContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint32",
+          "name": "newRollupTypeID",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "upgradeData",
+          "type": "bytes"
+        }
+      ],
+      "name": "updateRollup",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract ITransparentUpgradeableProxy",
+          "name": "rollupContract",
+          "type": "address"
+        },
+        {
+          "internalType": "uint32",
+          "name": "newRollupTypeID",
+          "type": "uint32"
+        }
+      ],
+      "name": "updateRollupByRollupAdmin",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint64",
+          "name": "pendingStateNum",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "initNumBatch",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "finalNewBatch",
+          "type": "uint64"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newLocalExitRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newStateRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "beneficiary",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes32[24]",
+          "name": "proof",
+          "type": "bytes32[24]"
+        }
+      ],
+      "name": "verifyBatchesTrustedAggregator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint32",
+          "name": "rollupID",
+          "type": "uint32"
+        },
+        {
+          "internalType": "uint32",
+          "name": "l1InfoTreeLeafCount",
+          "type": "uint32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newLocalExitRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "newPessimisticRoot",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "bytes",
+          "name": "proof",
+          "type": "bytes"
+        },
+        {
+          "internalType": "bytes",
+          "name": "customChainData",
+          "type": "bytes"
+        }
+      ],
+      "name": "verifyPessimisticTrustedAggregator",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x610100604052348015610010575f5ffd5b5060405161585e38038061585e83398101604081905261002f91610133565b6001600160a01b0380851660805283811660c05282811660a052811660e05261005661005f565b5050505061018f565b5f54610100900460ff16156100ca5760405162461bcd60e51b815260206004820152602760248201527f496e697469616c697a61626c653a20636f6e747261637420697320696e697469604482015266616c697a696e6760c81b606482015260840160405180910390fd5b5f5460ff908116101561011a575f805460ff191660ff9081179091556040519081527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a15b565b6001600160a01b0381168114610130575f5ffd5b50565b5f5f5f5f60808587031215610146575f5ffd5b84516101518161011c565b60208601519094506101628161011c565b60408601519093506101738161011c565b60608601519092506101848161011c565b939692955090935050565b60805160a05160c05160e0516156646101fa5f395f81816106cb0152610e1401525f8181610827015281816117d801526130f501525f818161068c0152818161275001526131f301525f818161076a01528181610a6a01528181610d330152610f1b01526156645ff3fe608060405234801561000f575f5ffd5b50600436106102f5575f3560e01c806399f5634e1161019d578063d5073f6f116100e8578063dfdb8c5e11610093578063e80e50301161006e578063e80e5030146108f7578063f4e926751461090a578063f9c4c2ae1461091a575f5ffd5b8063dfdb8c5e1461080f578063e46761c414610822578063e4f3d8f914610849575f5ffd5b8063dbc16976116100c3578063dbc16976146107da578063dd0464b9146107e2578063dde0ff77146107f5575f5ffd5b8063d5073f6f1461078c578063d547741f1461079f578063d8905812146107b2575f5ffd5b8063abcb519811610148578063c5b4fdb611610123578063c5b4fdb61461072d578063ceee281d14610740578063d02103ca14610765575f5ffd5b8063abcb5198146106ed578063c1acbc3414610700578063c4c928c21461071a575f5ffd5b8063a2967d9911610178578063a2967d991461067f578063a3c573eb14610687578063ab0475cf146106c6575f5ffd5b806399f5634e1461065d5780639a908e7314610665578063a217fddf14610678575f5ffd5b8063477fa2701161025d57806374d9c244116102085780638129fc1c116101e35780638129fc1c1461060a5780638fd88cc21461061257806391d1485414610625575f5ffd5b806374d9c244146105a55780637975fcfe146105c55780637fb6e76a146105e5575f5ffd5b806365c0504d1161023857806365c0504d146105045780636c7668771461057f5780637222020f14610592575f5ffd5b8063477fa270146104b457806355a71ee0146104bc57806360469169146104fc575f5ffd5b80632072f6c5116102bd5780632f2ff15d116102985780632f2ff15d1461047b57806330c27dde1461048e57806336568abe146104a1575f5ffd5b80632072f6c514610393578063248a9ca31461039b57806325280169146103cb575f5ffd5b8063066ec012146102f957806311f6b287146103295780631489ed101461033c57806315064c96146103515780631796a1ae1461036e575b5f5ffd5b60845461030c906001600160401b031681565b6040516001600160401b0390911681526020015b60405180910390f35b61030c610337366004613ec0565b61093a565b61034f61034a366004613f15565b610969565b005b606f5461035e9060ff1681565b6040519015158152602001610320565b607e5461037e9063ffffffff1681565b60405163ffffffff9091168152602001610320565b61034f610b4a565b6103bd6103a9366004613fa3565b5f9081526034602052604090206001015490565b604051908152602001610320565b6104486103d9366004613fba565b60408051606080820183525f808352602080840182905292840181905263ffffffff959095168552608182528285206001600160401b03948516865260030182529382902082519485018352805485526001015480841691850191909152600160401b90049091169082015290565b60408051825181526020808401516001600160401b03908116918301919091529282015190921690820152606001610320565b61034f610489366004613feb565b610c1c565b60875461030c906001600160401b031681565b61034f6104af366004613feb565b610c45565b6086546103bd565b6103bd6104ca366004613fba565b63ffffffff82165f9081526081602090815260408083206001600160401b038516845260020190915290205492915050565b6103bd610c7c565b61056c610512366004613ec0565b607f6020525f908152604090208054600182015460028301546003909301546001600160a01b0392831693928216926001600160401b03600160a01b8404169260ff600160e01b8204811693600160e81b90920416919087565b604051610320979695949392919061404d565b61034f61058d3660046140e3565b610c91565b61034f6105a0366004613ec0565b611081565b6105b86105b3366004613ec0565b611172565b6040516103209190614183565b6105d86105d3366004614291565b6112c1565b604051610320919061431a565b61037e6105f336600461432c565b60836020525f908152604090205463ffffffff1681565b61034f6112f1565b61034f610620366004614345565b611432565b61035e610633366004613feb565b5f9182526034602090815260408084206001600160a01b0393909316845291905290205460ff1690565b6103bd6117b7565b61030c610673366004614361565b611890565b6103bd5f81565b6103bd611a86565b6106ae7f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610320565b6106ae7f000000000000000000000000000000000000000000000000000000000000000081565b61034f6106fb36600461443a565b611dec565b60845461030c90600160801b90046001600160401b031681565b61034f6107283660046144cd565b6120e4565b61034f61073b366004614528565b61211f565b61037e61074e366004614605565b60826020525f908152604090205463ffffffff1681565b6106ae7f000000000000000000000000000000000000000000000000000000000000000081565b61034f61079a366004613fa3565b612636565b61034f6107ad366004613feb565b6126d4565b6105d8604051806040016040528060098152602001680616c2d76302e332e360bc1b81525081565b61034f6126f8565b6105d86107f0366004614620565b6127be565b60845461030c90600160401b90046001600160401b031681565b61034f61081d36600461468b565b6127e5565b6106ae7f000000000000000000000000000000000000000000000000000000000000000081565b6108df610857366004613ec0565b63ffffffff165f9081526081602052604090208054600182015460058301546006840154600785015460088601546009909601546001600160a01b0380871698600160a01b978890046001600160401b03908116999288169890970487169680861695600160401b908190048216958281169591810490921693600160801b90920460ff1692565b6040516103209c9b9a999897969594939291906146b5565b61034f610905366004614746565b612a0d565b60805461037e9063ffffffff1681565b61092d610928366004613ec0565b612d43565b60405161032091906147c7565b63ffffffff81165f90815260816020526040812060060154600160401b90046001600160401b03165b92915050565b7f084e94f375e9d647f87f5b2ceffba1e062c70f6009fdbcf80291e803b5c9edd461099381612e99565b6001600160401b038816156109bb5760405163306dfc5760e11b815260040160405180910390fd5b63ffffffff89165f908152608160205260408120906007820154600160801b900460ff1660028111156109f0576109f0614019565b14610a0e576040516390db0d0760e01b815260040160405180910390fd5b610a1d81898989898989612ea3565b6006810180546fffffffffffffffff00000000000000001916600160401b6001600160401b038a16908102919091179091555f9081526002820160205260409020859055600581018690557f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03166333d6247d610a9f611a86565b6040518263ffffffff1660e01b8152600401610abd91815260200190565b5f604051808303815f87803b158015610ad4575f5ffd5b505af1158015610ae6573d5f5f3e3d5ffd5b5050604080516001600160401b038b1681526020810189905290810189905233925063ffffffff8d1691507fd1ec3a1216f08b6eff72e169ceb548b782db18a6614852618d86bb19f3f9b0d39060600160405180910390a350505050505050505050565b335f9081527f8875b94af5657a2903def9906d67a3f42d8a836d24b5602c00f00fc855339fcd602052604090205460ff16610c1257608454600160801b90046001600160401b03161580610bc757506084544290610bbc9062093a8090600160801b90046001600160401b031661490b565b6001600160401b0316115b80610bf457506087544290610be99062093a80906001600160401b031661490b565b6001600160401b0316115b15610c125760405163692baaad60e11b815260040160405180910390fd5b610c1a6131f1565b565b5f82815260346020526040902060010154610c3681612e99565b610c408383613267565b505050565b6001600160a01b0381163314610c6e57604051630b4ad1cd60e31b815260040160405180910390fd5b610c7882826132ea565b5050565b5f6086546064610c8c919061492a565b905090565b7f084e94f375e9d647f87f5b2ceffba1e062c70f6009fdbcf80291e803b5c9edd4610cbb81612e99565b610cc361336b565b63ffffffff89165f908152608160205260408120906007820154600160801b900460ff166002811115610cf857610cf8614019565b03610d1657604051635b6602b760e01b815260040160405180910390fd5b60405163ef4eeb3560e01b815263ffffffff8a1660048201525f907f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03169063ef4eeb3590602401602060405180830381865afa158015610d80573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190610da49190614941565b905080610dc45760405163a60721e160e01b815260040160405180910390fd5b5f610dd48c84848d8d8b8b6133d8565b905060026007840154600160801b900460ff166002811115610df857610df8614019565b03610e7e5760405163a48fd37760e01b81526001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000169063a48fd37790610e4d9084908c908c90600401614980565b5f6040518083038186803b158015610e63575f5ffd5b505afa158015610e75573d5f5f3e3d5ffd5b50505050610ee6565b6001830154600984015460405163020a49e360e51b81526001600160a01b03909216916341493c6091610eb99185908d908d906004016149af565b5f6040518083038186803b158015610ecf575f5ffd5b505afa158015610ee1573d5f5f3e3d5ffd5b505050505b6084805467ffffffffffffffff60801b1916600160801b426001600160401b031602179055600583018a9055600883018990557f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03166333d6247d610f50611a86565b6040518263ffffffff1660e01b8152600401610f6e91815260200190565b5f604051808303815f87803b158015610f85575f5ffd5b505af1158015610f97573d5f5f3e3d5ffd5b5050604080515f80825260208201529081018d905233925063ffffffff8f1691507fd1ec3a1216f08b6eff72e169ceb548b782db18a6614852618d86bb19f3f9b0d39060600160405180910390a360026007840154600160801b900460ff16600281111561100757611007614019565b0361106b578254604051639ee4afa360e01b81526001600160a01b0390911690639ee4afa39061103d90899089906004016149da565b5f604051808303815f87803b158015611054575f5ffd5b505af1158015611066573d5f5f3e3d5ffd5b505050505b5050506110766135ad565b505050505050505050565b7fab66e11c4f712cd06ab11bf9339b48bef39e12d4a22eeef71d2860a0c90482bd6110ab81612e99565b63ffffffff821615806110c95750607e5463ffffffff908116908316115b156110e757604051637512e5cb60e01b815260040160405180910390fd5b63ffffffff82165f908152607f602052604090206001810154600160e81b900460ff161561112857604051633b8d3d9960e01b815260040160405180910390fd5b60018101805460ff60e81b1916600160e81b17905560405163ffffffff8416907f4710d2ee567ef1ed6eb2f651dde4589524bcf7cebc62147a99b281cc836e7e44905f90a2505050565b6111d560408051610180810182525f80825260208201819052918101829052606081018290526080810182905260a0810182905260c0810182905260e0810182905261010081018290529061012082019081526020015f81526020015f81525090565b63ffffffff82165f9081526081602090815260409182902080546001600160a01b0380821686526001600160401b03600160a01b928390048116948701949094526001830154908116948601949094529092048116606084015260058201546080840152600682015480821660a0850152600160401b90819004821660c0850152600783015480831660e086015290810490911661010084015261012083019060ff600160801b90910416600281111561129157611291614019565b908160028111156112a4576112a4614019565b905250600881015461014083015260090154610160820152919050565b63ffffffff86165f9081526081602052604090206060906112e69087878787876135d7565b979650505050505050565b5f54600490610100900460ff1615801561131157505f5460ff8083169116105b6113885760405162461bcd60e51b815260206004820152602e60248201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160448201527f647920696e697469616c697a656400000000000000000000000000000000000060648201526084015b60405180910390fd5b5f805461ffff191660ff83161761010017905560408051808201825260098152680616c2d76302e332e360bc1b602082015290517f50cadc0c001f05dd4b81db1e92b98d77e718fd2f103fb7b77293e867d329a4c2916113e79161431a565b60405180910390a15f805461ff001916905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a150565b335f9081527ff14f5a8ad59d90593602e905b358229bff5ceea677d5bf0f5a1701793550a9a6602052604090205460ff161580156114e15750336001600160a01b0316826001600160a01b031663f851a4406040518163ffffffff1660e01b8152600401602060405180830381865afa1580156114b1573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906114d591906149ed565b6001600160a01b031614155b156114ff57604051630d03687f60e11b815260040160405180910390fd5b6001600160a01b0382165f9081526082602052604081205463ffffffff169081900361153e576040516374a086a360e01b815260040160405180910390fd5b63ffffffff81165f908152608160205260408120906007820154600160801b900460ff16600281111561157357611573614019565b14611591576040516390db0d0760e01b815260040160405180910390fd5b60068101546001600160401b03908116908416811115806115c9575060068201546001600160401b03600160401b9091048116908516105b156115e75760405163cb23ebdf60e01b815260040160405180910390fd5b805b846001600160401b0316816001600160401b031614611688576001600160401b038082165f908152600385016020526040902060010154600160401b9004811690861681101561164c57604051639753965f60e01b815260040160405180910390fd5b6001600160401b039091165f908152600384016020526040812090815560010180546fffffffffffffffffffffffffffffffff191690556115e9565b60068301805467ffffffffffffffff19166001600160401b0387161790556116b08583614a08565b608480545f906116ca9084906001600160401b0316614a08565b82546101009290920a6001600160401b0381810219909316918316021790915586165f8181526003860160205260409081902054905163334d6f6760e11b8152600481019290925260248201526001600160a01b038816915063669adece906044015f604051808303815f87803b158015611743575f5ffd5b505af1158015611755573d5f5f3e3d5ffd5b505050506001600160401b0385165f81815260038501602090815260409182902054915191825263ffffffff8716917f80a6d395a55aed8126079cb8247f0a6848b1440ca2cdca3b4386f250c3529402910160405180910390a3505050505050565b6040516370a0823160e01b81523060048201525f9081906001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016906370a0823190602401602060405180830381865afa15801561181d573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906118419190614941565b6084549091505f90611865906001600160401b03600160401b820481169116614a08565b6001600160401b03169050805f0361187f575f9250505090565b6118898183614a3b565b9250505090565b606f545f9060ff16156118b657604051630bc011ff60e21b815260040160405180910390fd5b335f9081526082602052604081205463ffffffff16908190036118ec576040516371653c1560e01b815260040160405180910390fd5b836001600160401b03165f0361191557604051632590ccf960e01b815260040160405180910390fd5b63ffffffff81165f908152608160205260408120906007820154600160801b900460ff16600281111561194a5761194a614019565b14611968576040516390db0d0760e01b815260040160405180910390fd5b608480548691905f906119859084906001600160401b031661490b565b82546101009290920a6001600160401b0381810219909316918316021790915560068301541690505f6119b8878361490b565b6006840180546001600160401b0383811667ffffffffffffffff199092168217909255604080516060810182528a815242841660208083019182528886168385019081525f86815260038c018352859020935184559151600193909301805492518716600160401b026fffffffffffffffffffffffffffffffff199093169390961692909217179093555190815291925063ffffffff8616917f1d9f30260051d51d70339da239ea7b080021adcaabfa71c9b0ea339a20cf9a25910160405180910390a29695505050505050565b6080545f9063ffffffff16808203611a9f57505f919050565b5f816001600160401b03811115611ab857611ab8614397565b604051908082528060200260200182016040528015611ae1578160200160208202803683370190505b5090505f5b82811015611b3e5760815f611afc836001614a4e565b63ffffffff1663ffffffff1681526020019081526020015f2060050154828281518110611b2b57611b2b614a61565b6020908102919091010152600101611ae6565b505f60205b83600114611d59575f611b57600286614a75565b611b62600287614a3b565b611b6c9190614a4e565b90505f816001600160401b03811115611b8757611b87614397565b604051908082528060200260200182016040528015611bb0578160200160208202803683370190505b5090505f5b82811015611d0957611bc8600184614a88565b81148015611be05750611bdc600288614a75565b6001145b15611c5d5785611bf182600261492a565b81518110611c0157611c01614a61565b602002602001015185604051602001611c24929190918252602082015260400190565b60405160208183030381529060405280519060200120828281518110611c4c57611c4c614a61565b602002602001018181525050611d01565b85611c6982600261492a565b81518110611c7957611c79614a61565b602002602001015186826002611c8f919061492a565b611c9a906001614a4e565b81518110611caa57611caa614a61565b6020026020010151604051602001611ccc929190918252602082015260400190565b60405160208183030381529060405280519060200120828281518110611cf457611cf4614a61565b6020026020010181815250505b600101611bb5565b508094508195508384604051602001611d2c929190918252602082015260400190565b6040516020818303038152906040528051906020012093508280611d4f90614a9b565b9350505050611b43565b5f835f81518110611d6c57611d6c614a61565b602002602001015190505f5f90505b82811015611de257604080516020810184905290810185905260600160408051601f198184030181528282528051602091820120908301879052908201869052925060600160408051601f1981840301815291905280516020909101209350600101611d7b565b5095945050505050565b7fac75d24dbb35ea80e25fab167da4dea46c1915260426570db84f184891f5f590611e1681612e99565b607e80545f91908290611e2e9063ffffffff16614ab0565b91906101000a81548163ffffffff021916908363ffffffff1602179055905060016002811115611e6057611e60614019565b866002811115611e7257611e72614019565b03611e9b578415611e96576040516363d722e760e01b815260040160405180910390fd5b611f55565b6002866002811115611eaf57611eaf614019565b03611f05576001600160a01b038816151580611ed357506001600160401b03871615155b80611edd57508415155b80611ee757508215155b15611e96576040516363d722e760e01b815260040160405180910390fd5b5f866002811115611f1857611f18614019565b03611f3c578215611e96576040516363d722e760e01b815260040160405180910390fd5b6040516363d722e760e01b815260040160405180910390fd5b6040518060e001604052808a6001600160a01b03168152602001896001600160a01b03168152602001886001600160401b03168152602001876002811115611f9f57611f9f614019565b81525f602080830182905260408084018a9052606093840188905263ffffffff86168352607f825291829020845181546001600160a01b0391821673ffffffffffffffffffffffffffffffffffffffff1990911617825591850151600182018054948701516001600160401b0316600160a01b026001600160e01b031990951691909316179290921780825592840151919260ff60e01b1916600160e01b83600281111561204f5761204f614019565b02179055506080820151600182018054911515600160e81b0260ff60e81b1990921691909117905560a0820151600282015560c09091015160039091015560405163ffffffff8216907f9eaf2ecbddb14889c9e141a63175c55ac25e0cd7cdea312cdfbd0397976b383a906120d1908c908c908c908c908c908c908c90614ad4565b60405180910390a2505050505050505050565b7f66156603fe29d13f97c6f3e3dff4ef71919f9aa61c555be0182d954e94221aac61210e81612e99565b6121198484846136da565b50505050565b7fa0fab074aba36a6fa69f1a83ee86e5abfb8433966eb57efb13dc2fc2f24ddd0861214981612e99565b63ffffffff891615806121675750607e5463ffffffff908116908a16115b1561218557604051637512e5cb60e01b815260040160405180910390fd5b63ffffffff89165f908152607f602052604090206001810154600160e81b900460ff16156121c657604051633b8d3d9960e01b815260040160405180910390fd5b63ffffffff6001600160401b038a1611156121f457604051634c753f5760e01b815260040160405180910390fd5b6001600160401b0389165f9081526083602052604090205463ffffffff1615612230576040516337c8fe0960e11b815260040160405180910390fd5b608080545f919082906122489063ffffffff16614ab0565b825463ffffffff8281166101009490940a93840293021916919091179091558254604080515f80825260208201928390529394506001600160a01b0390921691309161229390613ea0565b61229f93929190614b3a565b604051809103905ff0801580156122b8573d5f5f3e3d5ffd5b5090508160835f8d6001600160401b03166001600160401b031681526020019081526020015f205f6101000a81548163ffffffff021916908363ffffffff1602179055508160825f836001600160a01b03166001600160a01b031681526020019081526020015f205f6101000a81548163ffffffff021916908363ffffffff1602179055505f60815f8463ffffffff1663ffffffff1681526020019081526020015f20905081815f015f6101000a8154816001600160a01b0302191690836001600160a01b031602179055508360010160149054906101000a90046001600160401b03168160010160146101000a8154816001600160401b0302191690836001600160401b03160217905550836001015f9054906101000a90046001600160a01b0316816001015f6101000a8154816001600160a01b0302191690836001600160a01b031602179055508b815f0160146101000a8154816001600160401b0302191690836001600160401b031602179055508360020154816002015f5f6001600160401b031681526020019081526020015f20819055508c63ffffffff168160070160086101000a8154816001600160401b0302191690836001600160401b0316021790555083600101601c9054906101000a900460ff168160070160106101000a81548160ff021916908360028111156124b5576124b5614019565b0217905550836003015481600901819055508263ffffffff167f194c983456df6701c6a50830b90fe80e72b823411d0d524970c9590dc277a6418e848f8d604051612536949392919063ffffffff9490941684526001600160a01b0392831660208501526001600160401b0391909116604084015216606082015260800190565b60405180910390a260026001850154600160e01b900460ff16600281111561256057612560614019565b036125c35760405163439fab9160e01b81526001600160a01b0383169063439fab919061259190899060040161431a565b5f604051808303815f87803b1580156125a8575f5ffd5b505af11580156125ba573d5f5f3e3d5ffd5b50505050612627565b604051633892b81160e11b81526001600160a01b038316906371257022906125f9908e908e9088908f908f908f90600401614b73565b5f604051808303815f87803b158015612610575f5ffd5b505af1158015612622573d5f5f3e3d5ffd5b505050505b50505050505050505050505050565b7f8cf807f6970720f8e2c208c7c5037595982c7bd9ed93c380d09df743d0dcc3fb61266081612e99565b683635c9adc5dea0000082118061267a5750633b9aca0082105b1561269857604051638586952560e01b815260040160405180910390fd5b60868290556040518281527ffb383653f53ee079978d0c9aff7aeff04a10166ce244cca9c9f9d8d96bed45b29060200160405180910390a15050565b5f828152603460205260409020600101546126ee81612e99565b610c4083836132ea565b7f62ba6ba2ffed8cfe316b583325ea41ac6e7ba9e5864d2bc6fabba7ac26d2f0f461272281612e99565b6087805467ffffffffffffffff1916426001600160401b031617905560408051636de0b4bb60e11b815290517f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03169163dbc16976916004808301925f92919082900301818387803b15801561279d575f5ffd5b505af11580156127af573d5f5f3e3d5ffd5b505050506127bb613a6e565b50565b63ffffffff86165f9081526081602052604090206060906112e690889088888888886133d8565b336001600160a01b0316826001600160a01b031663f851a4406040518163ffffffff1660e01b8152600401602060405180830381865afa15801561282b573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061284f91906149ed565b6001600160a01b0316146128765760405163696072e960e01b815260040160405180910390fd5b6001600160a01b0382165f9081526082602090815260408083205463ffffffff1683526081909152902060068101546001600160401b03808216600160401b90920416146128d75760405163664316a560e11b815260040160405180910390fd5b600263ffffffff83165f908152607f6020526040902060010154600160e01b900460ff16600281111561290c5761290c614019565b141580156129355750600781015463ffffffff8316600160401b9091046001600160401b031610155b1561295357604051633e37e23360e01b815260040160405180910390fd5b6001600160a01b0383165f9081526082602090815260408083205463ffffffff8681168552607f909352922060010154911690600160e01b900460ff1660028111156129a1576129a1614019565b63ffffffff82165f908152607f6020526040902060010154600160e01b900460ff1660028111156129d4576129d4614019565b146129f257604051635aa0d5f160e11b815260040160405180910390fd5b604080515f81526020810190915261211990859085906136da565b7f3dfe277d2a2c04b75fb2eb3743fa00005ae3678a20c299e65fdf4df76517f68e612a3781612e99565b6001600160401b0386165f9081526083602052604090205463ffffffff1615612a73576040516337c8fe0960e11b815260040160405180910390fd5b63ffffffff6001600160401b0387161115612aa157604051634c753f5760e01b815260040160405180910390fd5b6001600160a01b0389165f9081526082602052604090205463ffffffff1615612add57604051630d409b9360e41b815260040160405180910390fd5b608080545f91908290612af59063ffffffff16614ab0565b91906101000a81548163ffffffff021916908363ffffffff160217905590508060835f896001600160401b03166001600160401b031681526020019081526020015f205f6101000a81548163ffffffff021916908363ffffffff1602179055508060825f8c6001600160a01b03166001600160a01b031681526020019081526020015f205f6101000a81548163ffffffff021916908363ffffffff1602179055505f60815f8363ffffffff1663ffffffff1681526020019081526020015f2090508a815f015f6101000a8154816001600160a01b0302191690836001600160a01b03160217905550888160010160146101000a8154816001600160401b0302191690836001600160401b0316021790555089816001015f6101000a8154816001600160a01b0302191690836001600160a01b0316021790555087815f0160146101000a8154816001600160401b0302191690836001600160401b03160217905550858160070160106101000a81548160ff02191690836002811115612c7c57612c7c614019565b02179055506001866002811115612c9557612c95614019565b03612cad576009810185905560058101879055612cec565b6002866002811115612cc157612cc1614019565b03612cd9576008810184905560058101879055612cec565b5f80805260028201602052604090208790555b8163ffffffff167f4da47f6e9bbd9ef91887183a576aaebcf1b9bb7d2a567b33b075044c6d36082e8a8d8b8a5f8b8b604051612d2e9796959493929190614bdd565b60405180910390a25050505050505050505050565b612da760408051610180810182525f80825260208201819052918101829052606081018290526080810182905260a0810182905260c0810182905260e081018290526101008101829052610120810182905261014081018290529061016082015290565b63ffffffff82165f9081526081602090815260409182902080546001600160a01b038082168652600160a01b918290046001600160401b03908116948701949094526001830154908116948601949094529092048116606084015260058201546080840152600682015480821660a0850152600160401b808204831660c0860152600160801b808304841660e0870152600160c01b909204831661010086015260078401548084166101208701529081049092166101408501526101608401910460ff166002811115612e7c57612e7c614019565b90816002811115612e8f57612e8f614019565b8152505050919050565b6127bb8133613ac5565b5f5f612ec189600601546001600160401b03600160401b9091041690565b60078a01549091506001600160401b039081169089161015612ef65760405163ead1340b60e01b815260040160405180910390fd5b6001600160401b0388165f90815260028a016020526040902054915081612f30576040516324cbdcc360e11b815260040160405180910390fd5b806001600160401b0316886001600160401b03161115612f6357604051630f2b74f160e11b815260040160405180910390fd5b806001600160401b0316876001600160401b031611612f955760405163b9b18f5760e01b815260040160405180910390fd5b5f612fa48a8a8a8a878b6135d7565b90505f7f30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001600283604051612fd89190614c38565b602060405180830381855afa158015612ff3573d5f5f3e3d5ffd5b5050506040513d601f19601f820116820180604052508101906130169190614941565b6130209190614a75565b60018c0154604080516020810182528381529051634890ed4560e11b81529293506001600160a01b0390911691639121da8a9161306291899190600401614c4e565b602060405180830381865afa15801561307d573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906130a19190614c8a565b6130be576040516309bde33960e01b815260040160405180910390fd5b5f6130c9848b614a08565b905061311c87826001600160401b03166130e16117b7565b6130eb919061492a565b6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000169190613b07565b80608460088282829054906101000a90046001600160401b0316613140919061490b565b82546101009290920a6001600160401b038181021990931691831602179091556084805467ffffffffffffffff60801b1916600160801b428416021790558d546040516332c2d15360e01b8152918d166004830152602482018b90523360448301526001600160a01b031691506332c2d153906064015f604051808303815f87803b1580156131cd575f5ffd5b505af11580156131df573d5f5f3e3d5ffd5b50505050505050505050505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632072f6c56040518163ffffffff1660e01b81526004015f604051808303815f87803b158015613249575f5ffd5b505af115801561325b573d5f5f3e3d5ffd5b50505050610c1a613b6e565b5f8281526034602090815260408083206001600160a01b038516845290915290205460ff16610c78575f8281526034602090815260408083206001600160a01b0385168085529252808320805460ff1916600117905551339285917f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d9190a45050565b5f8281526034602090815260408083206001600160a01b038516845290915290205460ff1615610c78575f8281526034602090815260408083206001600160a01b0385168085529252808320805460ff1916905551339285917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a45050565b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c156133ab57604051633ee5aeb560e01b815260040160405180910390fd5b610c1a60017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005b90613bc9565b606060026007880154600160801b900460ff1660028111156133fc576133fc614019565b036134d7578654604051631a957d9b60e21b81525f916001600160a01b031690636a55f66c9061343290879087906004016149da565b602060405180830381865afa15801561344d573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906134719190614941565b600589015460088a0154604080516020810193909352820152606081018990526001600160e01b031960e08c901b1660808201526084810182905260a4810188905260c4810187905290915060e4016040516020818303038152906040529150506112e6565b865460408051632b47b7cd60e21b815290515f926001600160a01b03169163ad1edf349160048083019260209291908290030181865afa15801561351d573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906135419190614941565b600589015460088a0154604080516020810193909352820152606081018990526001600160e01b031960e08c901b1660808201526084810182905260a4810188905260c4810187905290915060e401604051602081830303815290604052915050979650505050505050565b610c1a5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f006133d2565b6001600160401b038086165f818152600389016020526040808220549388168252902054606092911580159061360b575081155b156136295760405163340c614f60e11b815260040160405180910390fd5b80613647576040516366385b5160e01b815260040160405180910390fd5b61365084613bd0565b61366d576040516305dae44f60e21b815260040160405180910390fd5b3385838a8c5f0160149054906101000a90046001600160401b03168d60010160149054906101000a90046001600160401b031689878d8f6040516020016136bd9a99989796959493929190614ca9565b604051602081830303815290604052925050509695505050505050565b63ffffffff821615806136f85750607e5463ffffffff908116908316115b1561371657604051637512e5cb60e01b815260040160405180910390fd5b6001600160a01b0383165f9081526082602052604081205463ffffffff1690819003613755576040516374a086a360e01b815260040160405180910390fd5b63ffffffff8181165f908152608160205260409020600781015490918516600160401b9091046001600160401b0316036137a257604051634f61d51960e01b815260040160405180910390fd5b63ffffffff84165f908152607f602052604090206001810154600160e81b900460ff16156137e357604051633b8d3d9960e01b815260040160405180910390fd5b60026001820154600160e01b900460ff16600281111561380557613805614019565b146138a85760026007830154600160801b900460ff16600281111561382c5761382c614019565b0361384a57604051635aa0d5f160e11b815260040160405180910390fd5b6001810154600160e01b900460ff16600281111561386a5761386a614019565b6007830154600160801b900460ff16600281111561388a5761388a614019565b146138a857604051635aa0d5f160e11b815260040160405180910390fd5b60018082018054918401805473ffffffffffffffffffffffffffffffffffffffff1981166001600160a01b03909416938417825582546001600160401b03600160a01b9182900416026001600160e01b03199091169093179290921790915560038201546009840155600783018054600160401b63ffffffff8916026fffffffffffffffff000000000000000019821681178355925460ff600160e01b909104169270ff00000000000000000000000000000000191670ffffffffffffffffff00000000000000001990911617600160801b83600281111561398c5761398c614019565b02179055505f61399b8461093a565b60078401805467ffffffffffffffff19166001600160401b038316179055825460405163278f794360e11b81529192506001600160a01b0389811692634f1ef286926139ed9216908990600401614d5d565b5f604051808303815f87803b158015613a04575f5ffd5b505af1158015613a16573d5f5f3e3d5ffd5b50506040805163ffffffff8a811682526001600160401b0386166020830152881693507ff585e04c05d396901170247783d3e5f0ee9c1df23072985b50af089f5e48b19d92500160405180910390a250505050505050565b606f5460ff16613a9157604051635386698160e01b815260040160405180910390fd5b606f805460ff191690556040517f1e5e34eea33501aecf2ebec9fe0e884a40804275ea7fe10b2ba084c8374308b3905f90a1565b5f8281526034602090815260408083206001600160a01b038516845290915290205460ff16610c7857604051637615be1f60e11b815260040160405180910390fd5b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff1663a9059cbb60e01b179052610c40908490613c55565b606f5460ff1615613b9257604051630bc011ff60e21b815260040160405180910390fd5b606f805460ff191660011790556040517f2261efe5aef6fedc1fd1550b25facc9181745623049c7901287030b9ad1a5497905f90a1565b80825d5050565b5f67ffffffff000000016001600160401b038316108015613c05575067ffffffff00000001604083901c6001600160401b0316105b8015613c25575067ffffffff00000001608083901c6001600160401b0316105b8015613c3c575067ffffffff0000000160c083901c105b15613c4957506001919050565b505f919050565b919050565b5f613ca9826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b0316613d269092919063ffffffff16565b805190915015610c405780806020019051810190613cc79190614c8a565b610c405760405162461bcd60e51b815260206004820152602a60248201527f5361666545524332303a204552433230206f7065726174696f6e20646964206e6044820152691bdd081cdd58d8d9595960b21b606482015260840161137f565b6060613d3484845f85613d3c565b949350505050565b606082471015613d9d5760405162461bcd60e51b815260206004820152602660248201527f416464726573733a20696e73756666696369656e742062616c616e636520666f6044820152651c8818d85b1b60d21b606482015260840161137f565b5f5f866001600160a01b03168587604051613db89190614c38565b5f6040518083038185875af1925050503d805f8114613df2576040519150601f19603f3d011682016040523d82523d5f602084013e613df7565b606091505b50915091506112e68783838760608315613e715782515f03613e6a576001600160a01b0385163b613e6a5760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e7472616374000000604482015260640161137f565b5081613d34565b613d348383815115613e865781518083602001fd5b8060405162461bcd60e51b815260040161137f919061431a565b6108b080614d7f83390190565b803563ffffffff81168114613c50575f5ffd5b5f60208284031215613ed0575f5ffd5b613ed982613ead565b9392505050565b80356001600160401b0381168114613c50575f5ffd5b6001600160a01b03811681146127bb575f5ffd5b8035613c5081613ef6565b5f5f5f5f5f5f5f5f6103e0898b031215613f2d575f5ffd5b613f3689613ead565b9750613f4460208a01613ee0565b9650613f5260408a01613ee0565b9550613f6060608a01613ee0565b94506080890135935060a0890135925060c0890135613f7e81613ef6565b91506103e089018a1015613f90575f5ffd5b60e0890190509295985092959890939650565b5f60208284031215613fb3575f5ffd5b5035919050565b5f5f60408385031215613fcb575f5ffd5b613fd483613ead565b9150613fe260208401613ee0565b90509250929050565b5f5f60408385031215613ffc575f5ffd5b82359150602083013561400e81613ef6565b809150509250929050565b634e487b7160e01b5f52602160045260245ffd5b6003811061404957634e487b7160e01b5f52602160045260245ffd5b9052565b6001600160a01b038881168252871660208201526001600160401b038616604082015260e08101614081606083018761402d565b931515608082015260a081019290925260c090910152949350505050565b5f5f83601f8401126140af575f5ffd5b5081356001600160401b038111156140c5575f5ffd5b6020830191508360208285010111156140dc575f5ffd5b9250929050565b5f5f5f5f5f5f5f5f60c0898b0312156140fa575f5ffd5b61410389613ead565b975061411160208a01613ead565b9650604089013595506060890135945060808901356001600160401b03811115614139575f5ffd5b6141458b828c0161409f565b90955093505060a08901356001600160401b03811115614163575f5ffd5b61416f8b828c0161409f565b999c989b5096995094979396929594505050565b81516001600160a01b03168152610180810160208301516141af60208401826001600160401b03169052565b5060408301516141ca60408401826001600160a01b03169052565b5060608301516141e560608401826001600160401b03169052565b506080830151608083015260a083015161420a60a08401826001600160401b03169052565b5060c083015161422560c08401826001600160401b03169052565b5060e083015161424060e08401826001600160401b03169052565b5061010083015161425d6101008401826001600160401b03169052565b5061012083015161427261012084018261402d565b5061014083015161014083015261016083015161016083015292915050565b5f5f5f5f5f5f60c087890312156142a6575f5ffd5b6142af87613ead565b95506142bd60208801613ee0565b94506142cb60408801613ee0565b959894975094956060810135955060808101359460a0909101359350915050565b5f81518084528060208401602086015e5f602082860101526020601f19601f83011685010191505092915050565b602081525f613ed960208301846142ec565b5f6020828403121561433c575f5ffd5b613ed982613ee0565b5f5f60408385031215614356575f5ffd5b8235613fd481613ef6565b5f5f60408385031215614372575f5ffd5b61437b83613ee0565b946020939093013593505050565b803560038110613c50575f5ffd5b634e487b7160e01b5f52604160045260245ffd5b5f82601f8301126143ba575f5ffd5b8135602083015f5f6001600160401b038411156143d9576143d9614397565b50604051601f19601f85018116603f011681018181106001600160401b038211171561440757614407614397565b60405283815290508082840187101561441e575f5ffd5b838360208301375f602085830101528094505050505092915050565b5f5f5f5f5f5f5f60e0888a031215614450575f5ffd5b873561445b81613ef6565b9650602088013561446b81613ef6565b955061447960408901613ee0565b945061448760608901614389565b93506080880135925060a08801356001600160401b038111156144a8575f5ffd5b6144b48a828b016143ab565b979a969950949793969295929450505060c09091013590565b5f5f5f606084860312156144df575f5ffd5b83356144ea81613ef6565b92506144f860208501613ead565b915060408401356001600160401b03811115614512575f5ffd5b61451e868287016143ab565b9150509250925092565b5f5f5f5f5f5f5f5f610100898b031215614540575f5ffd5b61454989613ead565b975061455760208a01613ee0565b965061456560408a01613f0a565b955061457360608a01613f0a565b945061458160808a01613f0a565b935060a08901356001600160401b0381111561459b575f5ffd5b6145a78b828c016143ab565b93505060c08901356001600160401b038111156145c2575f5ffd5b6145ce8b828c016143ab565b92505060e08901356001600160401b038111156145e9575f5ffd5b6145f58b828c016143ab565b9150509295985092959890939650565b5f60208284031215614615575f5ffd5b8135613ed981613ef6565b5f5f5f5f5f5f60a08789031215614635575f5ffd5b61463e87613ead565b955060208701359450604087013593506060870135925060808701356001600160401b0381111561466d575f5ffd5b61467989828a0161409f565b979a9699509497509295939492505050565b5f5f6040838503121561469c575f5ffd5b82356146a781613ef6565b9150613fe260208401613ead565b6001600160a01b038d811682526001600160401b038d81166020840152908c1660408301528a81166060830152608082018a905288811660a0830152871660c082015261018081016001600160401b03871660e08301526001600160401b03861661010083015261472a61012083018661402d565b61014082019390935261016001529a9950505050505050505050565b5f5f5f5f5f5f5f5f610100898b03121561475e575f5ffd5b883561476981613ef6565b9750602089013561477981613ef6565b965061478760408a01613ee0565b955061479560608a01613ee0565b9450608089013593506147aa60a08a01614389565b979a969950949793969295929450505060c08201359160e0013590565b81516001600160a01b03168152610180810160208301516147f360208401826001600160401b03169052565b50604083015161480e60408401826001600160a01b03169052565b50606083015161482960608401826001600160401b03169052565b506080830151608083015260a083015161484e60a08401826001600160401b03169052565b5060c083015161486960c08401826001600160401b03169052565b5060e083015161488460e08401826001600160401b03169052565b506101008301516148a16101008401826001600160401b03169052565b506101208301516148be6101208401826001600160401b03169052565b506101408301516148db6101408401826001600160401b03169052565b506101608301516148f061016084018261402d565b5092915050565b634e487b7160e01b5f52601160045260245ffd5b6001600160401b038181168382160190811115610963576109636148f7565b8082028115828204841417610963576109636148f7565b5f60208284031215614951575f5ffd5b5051919050565b81835281816020850137505f828201602090810191909152601f909101601f19169091010190565b604081525f61499260408301866142ec565b82810360208401526149a5818587614958565b9695505050505050565b848152606060208201525f6149c760608301866142ec565b82810360408401526112e6818587614958565b602081525f613d34602083018486614958565b5f602082840312156149fd575f5ffd5b8151613ed981613ef6565b6001600160401b038281168282160390811115610963576109636148f7565b634e487b7160e01b5f52601260045260245ffd5b5f82614a4957614a49614a27565b500490565b80820180821115610963576109636148f7565b634e487b7160e01b5f52603260045260245ffd5b5f82614a8357614a83614a27565b500690565b81810381811115610963576109636148f7565b5f81614aa957614aa96148f7565b505f190190565b5f63ffffffff821663ffffffff8103614acb57614acb6148f7565b60010192915050565b6001600160a01b03881681526001600160a01b03871660208201526001600160401b0386166040820152614b0b606082018661402d565b83608082015260e060a08201525f614b2660e08301856142ec565b90508260c083015298975050505050505050565b6001600160a01b03841681526001600160a01b0383166020820152606060408201525f614b6a60608301846142ec565b95945050505050565b6001600160a01b03871681526001600160a01b038616602082015263ffffffff851660408201526001600160a01b038416606082015260c060808201525f614bbe60c08301856142ec565b82810360a0840152614bd081856142ec565b9998505050505050505050565b6001600160401b0388811682526001600160a01b03881660208301528616604082015260e08101614c11606083018761402d565b6001600160401b03851660808301528360a08301528260c083015298975050505050505050565b5f82518060208501845e5f920191825250919050565b61032081016103008483376103008201835f5b6001811015614c80578151835260209283019290910190600101614c61565b5050509392505050565b5f60208284031215614c9a575f5ffd5b81518015158114613ed9575f5ffd5b6bffffffffffffffffffffffff198b60601b1681528960148201528860348201526001600160401b0360c01b8860c01b1660548201526001600160401b0360c01b8760c01b16605c8201526001600160401b0360c01b8660c01b16606482015284606c82015283608c8201528260ac820152614d4c60cc82018360c01b7fffffffffffffffff000000000000000000000000000000000000000000000000169052565b60d4019a9950505050505050505050565b6001600160a01b0383168152604060208201525f613d3460408301846142ec56fe60a06040526040516108b03803806108b083398101604081905261002291610327565b828161002e8282610056565b50506001600160a01b03821660805261004e61004960805190565b6100b4565b50505061040e565b61005f82610121565b6040516001600160a01b038316907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b905f90a28051156100a8576100a3828261019f565b505050565b6100b0610212565b5050565b7f7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f6100f35f5160206108905f395f51905f52546001600160a01b031690565b604080516001600160a01b03928316815291841660208301520160405180910390a161011e81610233565b50565b806001600160a01b03163b5f0361015b57604051634c9c8ce360e01b81526001600160a01b03821660048201526024015b60405180910390fd5b807f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5b80546001600160a01b0319166001600160a01b039290921691909117905550565b60605f5f846001600160a01b0316846040516101bb91906103f8565b5f60405180830381855af49150503d805f81146101f3576040519150601f19603f3d011682016040523d82523d5f602084013e6101f8565b606091505b509092509050610209858383610270565b95945050505050565b34156102315760405163b398979f60e01b815260040160405180910390fd5b565b6001600160a01b03811661025c57604051633173bdd160e11b81525f6004820152602401610152565b805f5160206108905f395f51905f5261017e565b60608261028557610280826102cf565b6102c8565b815115801561029c57506001600160a01b0384163b155b156102c557604051639996b31560e01b81526001600160a01b0385166004820152602401610152565b50805b9392505050565b8051156102df5780518082602001fd5b604051630a12f52160e11b815260040160405180910390fd5b80516001600160a01b038116811461030e575f5ffd5b919050565b634e487b7160e01b5f52604160045260245ffd5b5f5f5f60608486031215610339575f5ffd5b610342846102f8565b9250610350602085016102f8565b60408501519092506001600160401b0381111561036b575f5ffd5b8401601f8101861361037b575f5ffd5b80516001600160401b0381111561039457610394610313565b604051601f8201601f19908116603f011681016001600160401b03811182821017156103c2576103c2610313565b6040528181528282016020018810156103d9575f5ffd5b8160208401602083015e5f602083830101528093505050509250925092565b5f82518060208501845e5f920191825250919050565b60805161046b6104255f395f6010015261046b5ff3fe608060405261000c61000e565b005b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163303610081575f357fffffffff000000000000000000000000000000000000000000000000000000001663278f794360e11b1461007957610077610085565b565b610077610095565b6100775b6100776100906100c3565b6100fa565b5f806100a43660048184610313565b8101906100b1919061034e565b915091506100bf8282610118565b5050565b5f6100f57f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc546001600160a01b031690565b905090565b365f5f375f5f365f845af43d5f5f3e808015610114573d5ff35b3d5ffd5b61012182610172565b6040516001600160a01b038316907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b905f90a280511561016a5761016582826101fa565b505050565b6100bf61026c565b806001600160a01b03163b5f036101ac57604051634c9c8ce360e01b81526001600160a01b03821660048201526024015b60405180910390fd5b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc805473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b0392909216919091179055565b60605f5f846001600160a01b031684604051610216919061041f565b5f60405180830381855af49150503d805f811461024e576040519150601f19603f3d011682016040523d82523d5f602084013e610253565b606091505b509150915061026385838361028b565b95945050505050565b34156100775760405163b398979f60e01b815260040160405180910390fd5b6060826102a05761029b826102ea565b6102e3565b81511580156102b757506001600160a01b0384163b155b156102e057604051639996b31560e01b81526001600160a01b03851660048201526024016101a3565b50805b9392505050565b8051156102fa5780518082602001fd5b604051630a12f52160e11b815260040160405180910390fd5b5f5f85851115610321575f5ffd5b8386111561032d575f5ffd5b5050820193919092039150565b634e487b7160e01b5f52604160045260245ffd5b5f5f6040838503121561035f575f5ffd5b82356001600160a01b0381168114610375575f5ffd5b9150602083013567ffffffffffffffff811115610390575f5ffd5b8301601f810185136103a0575f5ffd5b803567ffffffffffffffff8111156103ba576103ba61033a565b604051601f8201601f19908116603f0116810167ffffffffffffffff811182821017156103e9576103e961033a565b604052818152828201602001871015610400575f5ffd5b816020840160208301375f602083830101528093505050509250929050565b5f82518060208501845e5f92019182525091905056fea2646970667358221220f0c40b8d0bc55a45013a71ee3fd7264ce873fcc561d04a41ba1f24adbcef958c64736f6c634300081c0033b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103a26469706673582212203a3c88f208edab75cb7577e66ab98dc612d1c8038cb4bdfda5cc5cf947a1d89164736f6c634300081c0033",
+  "deployedBytecode": "0x608060405234801561000f575f5ffd5b50600436106102f5575f3560e01c806399f5634e1161019d578063d5073f6f116100e8578063dfdb8c5e11610093578063e80e50301161006e578063e80e5030146108f7578063f4e926751461090a578063f9c4c2ae1461091a575f5ffd5b8063dfdb8c5e1461080f578063e46761c414610822578063e4f3d8f914610849575f5ffd5b8063dbc16976116100c3578063dbc16976146107da578063dd0464b9146107e2578063dde0ff77146107f5575f5ffd5b8063d5073f6f1461078c578063d547741f1461079f578063d8905812146107b2575f5ffd5b8063abcb519811610148578063c5b4fdb611610123578063c5b4fdb61461072d578063ceee281d14610740578063d02103ca14610765575f5ffd5b8063abcb5198146106ed578063c1acbc3414610700578063c4c928c21461071a575f5ffd5b8063a2967d9911610178578063a2967d991461067f578063a3c573eb14610687578063ab0475cf146106c6575f5ffd5b806399f5634e1461065d5780639a908e7314610665578063a217fddf14610678575f5ffd5b8063477fa2701161025d57806374d9c244116102085780638129fc1c116101e35780638129fc1c1461060a5780638fd88cc21461061257806391d1485414610625575f5ffd5b806374d9c244146105a55780637975fcfe146105c55780637fb6e76a146105e5575f5ffd5b806365c0504d1161023857806365c0504d146105045780636c7668771461057f5780637222020f14610592575f5ffd5b8063477fa270146104b457806355a71ee0146104bc57806360469169146104fc575f5ffd5b80632072f6c5116102bd5780632f2ff15d116102985780632f2ff15d1461047b57806330c27dde1461048e57806336568abe146104a1575f5ffd5b80632072f6c514610393578063248a9ca31461039b57806325280169146103cb575f5ffd5b8063066ec012146102f957806311f6b287146103295780631489ed101461033c57806315064c96146103515780631796a1ae1461036e575b5f5ffd5b60845461030c906001600160401b031681565b6040516001600160401b0390911681526020015b60405180910390f35b61030c610337366004613ec0565b61093a565b61034f61034a366004613f15565b610969565b005b606f5461035e9060ff1681565b6040519015158152602001610320565b607e5461037e9063ffffffff1681565b60405163ffffffff9091168152602001610320565b61034f610b4a565b6103bd6103a9366004613fa3565b5f9081526034602052604090206001015490565b604051908152602001610320565b6104486103d9366004613fba565b60408051606080820183525f808352602080840182905292840181905263ffffffff959095168552608182528285206001600160401b03948516865260030182529382902082519485018352805485526001015480841691850191909152600160401b90049091169082015290565b60408051825181526020808401516001600160401b03908116918301919091529282015190921690820152606001610320565b61034f610489366004613feb565b610c1c565b60875461030c906001600160401b031681565b61034f6104af366004613feb565b610c45565b6086546103bd565b6103bd6104ca366004613fba565b63ffffffff82165f9081526081602090815260408083206001600160401b038516845260020190915290205492915050565b6103bd610c7c565b61056c610512366004613ec0565b607f6020525f908152604090208054600182015460028301546003909301546001600160a01b0392831693928216926001600160401b03600160a01b8404169260ff600160e01b8204811693600160e81b90920416919087565b604051610320979695949392919061404d565b61034f61058d3660046140e3565b610c91565b61034f6105a0366004613ec0565b611081565b6105b86105b3366004613ec0565b611172565b6040516103209190614183565b6105d86105d3366004614291565b6112c1565b604051610320919061431a565b61037e6105f336600461432c565b60836020525f908152604090205463ffffffff1681565b61034f6112f1565b61034f610620366004614345565b611432565b61035e610633366004613feb565b5f9182526034602090815260408084206001600160a01b0393909316845291905290205460ff1690565b6103bd6117b7565b61030c610673366004614361565b611890565b6103bd5f81565b6103bd611a86565b6106ae7f000000000000000000000000000000000000000000000000000000000000000081565b6040516001600160a01b039091168152602001610320565b6106ae7f000000000000000000000000000000000000000000000000000000000000000081565b61034f6106fb36600461443a565b611dec565b60845461030c90600160801b90046001600160401b031681565b61034f6107283660046144cd565b6120e4565b61034f61073b366004614528565b61211f565b61037e61074e366004614605565b60826020525f908152604090205463ffffffff1681565b6106ae7f000000000000000000000000000000000000000000000000000000000000000081565b61034f61079a366004613fa3565b612636565b61034f6107ad366004613feb565b6126d4565b6105d8604051806040016040528060098152602001680616c2d76302e332e360bc1b81525081565b61034f6126f8565b6105d86107f0366004614620565b6127be565b60845461030c90600160401b90046001600160401b031681565b61034f61081d36600461468b565b6127e5565b6106ae7f000000000000000000000000000000000000000000000000000000000000000081565b6108df610857366004613ec0565b63ffffffff165f9081526081602052604090208054600182015460058301546006840154600785015460088601546009909601546001600160a01b0380871698600160a01b978890046001600160401b03908116999288169890970487169680861695600160401b908190048216958281169591810490921693600160801b90920460ff1692565b6040516103209c9b9a999897969594939291906146b5565b61034f610905366004614746565b612a0d565b60805461037e9063ffffffff1681565b61092d610928366004613ec0565b612d43565b60405161032091906147c7565b63ffffffff81165f90815260816020526040812060060154600160401b90046001600160401b03165b92915050565b7f084e94f375e9d647f87f5b2ceffba1e062c70f6009fdbcf80291e803b5c9edd461099381612e99565b6001600160401b038816156109bb5760405163306dfc5760e11b815260040160405180910390fd5b63ffffffff89165f908152608160205260408120906007820154600160801b900460ff1660028111156109f0576109f0614019565b14610a0e576040516390db0d0760e01b815260040160405180910390fd5b610a1d81898989898989612ea3565b6006810180546fffffffffffffffff00000000000000001916600160401b6001600160401b038a16908102919091179091555f9081526002820160205260409020859055600581018690557f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03166333d6247d610a9f611a86565b6040518263ffffffff1660e01b8152600401610abd91815260200190565b5f604051808303815f87803b158015610ad4575f5ffd5b505af1158015610ae6573d5f5f3e3d5ffd5b5050604080516001600160401b038b1681526020810189905290810189905233925063ffffffff8d1691507fd1ec3a1216f08b6eff72e169ceb548b782db18a6614852618d86bb19f3f9b0d39060600160405180910390a350505050505050505050565b335f9081527f8875b94af5657a2903def9906d67a3f42d8a836d24b5602c00f00fc855339fcd602052604090205460ff16610c1257608454600160801b90046001600160401b03161580610bc757506084544290610bbc9062093a8090600160801b90046001600160401b031661490b565b6001600160401b0316115b80610bf457506087544290610be99062093a80906001600160401b031661490b565b6001600160401b0316115b15610c125760405163692baaad60e11b815260040160405180910390fd5b610c1a6131f1565b565b5f82815260346020526040902060010154610c3681612e99565b610c408383613267565b505050565b6001600160a01b0381163314610c6e57604051630b4ad1cd60e31b815260040160405180910390fd5b610c7882826132ea565b5050565b5f6086546064610c8c919061492a565b905090565b7f084e94f375e9d647f87f5b2ceffba1e062c70f6009fdbcf80291e803b5c9edd4610cbb81612e99565b610cc361336b565b63ffffffff89165f908152608160205260408120906007820154600160801b900460ff166002811115610cf857610cf8614019565b03610d1657604051635b6602b760e01b815260040160405180910390fd5b60405163ef4eeb3560e01b815263ffffffff8a1660048201525f907f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03169063ef4eeb3590602401602060405180830381865afa158015610d80573d5f5f3e3d5ffd5b505050506040513d601f19601f82011682018060405250810190610da49190614941565b905080610dc45760405163a60721e160e01b815260040160405180910390fd5b5f610dd48c84848d8d8b8b6133d8565b905060026007840154600160801b900460ff166002811115610df857610df8614019565b03610e7e5760405163a48fd37760e01b81526001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000169063a48fd37790610e4d9084908c908c90600401614980565b5f6040518083038186803b158015610e63575f5ffd5b505afa158015610e75573d5f5f3e3d5ffd5b50505050610ee6565b6001830154600984015460405163020a49e360e51b81526001600160a01b03909216916341493c6091610eb99185908d908d906004016149af565b5f6040518083038186803b158015610ecf575f5ffd5b505afa158015610ee1573d5f5f3e3d5ffd5b505050505b6084805467ffffffffffffffff60801b1916600160801b426001600160401b031602179055600583018a9055600883018990557f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03166333d6247d610f50611a86565b6040518263ffffffff1660e01b8152600401610f6e91815260200190565b5f604051808303815f87803b158015610f85575f5ffd5b505af1158015610f97573d5f5f3e3d5ffd5b5050604080515f80825260208201529081018d905233925063ffffffff8f1691507fd1ec3a1216f08b6eff72e169ceb548b782db18a6614852618d86bb19f3f9b0d39060600160405180910390a360026007840154600160801b900460ff16600281111561100757611007614019565b0361106b578254604051639ee4afa360e01b81526001600160a01b0390911690639ee4afa39061103d90899089906004016149da565b5f604051808303815f87803b158015611054575f5ffd5b505af1158015611066573d5f5f3e3d5ffd5b505050505b5050506110766135ad565b505050505050505050565b7fab66e11c4f712cd06ab11bf9339b48bef39e12d4a22eeef71d2860a0c90482bd6110ab81612e99565b63ffffffff821615806110c95750607e5463ffffffff908116908316115b156110e757604051637512e5cb60e01b815260040160405180910390fd5b63ffffffff82165f908152607f602052604090206001810154600160e81b900460ff161561112857604051633b8d3d9960e01b815260040160405180910390fd5b60018101805460ff60e81b1916600160e81b17905560405163ffffffff8416907f4710d2ee567ef1ed6eb2f651dde4589524bcf7cebc62147a99b281cc836e7e44905f90a2505050565b6111d560408051610180810182525f80825260208201819052918101829052606081018290526080810182905260a0810182905260c0810182905260e0810182905261010081018290529061012082019081526020015f81526020015f81525090565b63ffffffff82165f9081526081602090815260409182902080546001600160a01b0380821686526001600160401b03600160a01b928390048116948701949094526001830154908116948601949094529092048116606084015260058201546080840152600682015480821660a0850152600160401b90819004821660c0850152600783015480831660e086015290810490911661010084015261012083019060ff600160801b90910416600281111561129157611291614019565b908160028111156112a4576112a4614019565b905250600881015461014083015260090154610160820152919050565b63ffffffff86165f9081526081602052604090206060906112e69087878787876135d7565b979650505050505050565b5f54600490610100900460ff1615801561131157505f5460ff8083169116105b6113885760405162461bcd60e51b815260206004820152602e60248201527f496e697469616c697a61626c653a20636f6e747261637420697320616c72656160448201527f647920696e697469616c697a656400000000000000000000000000000000000060648201526084015b60405180910390fd5b5f805461ffff191660ff83161761010017905560408051808201825260098152680616c2d76302e332e360bc1b602082015290517f50cadc0c001f05dd4b81db1e92b98d77e718fd2f103fb7b77293e867d329a4c2916113e79161431a565b60405180910390a15f805461ff001916905560405160ff821681527f7f26b83ff96e1f2b6a682f133852f6798a09c465da95921460cefb38474024989060200160405180910390a150565b335f9081527ff14f5a8ad59d90593602e905b358229bff5ceea677d5bf0f5a1701793550a9a6602052604090205460ff161580156114e15750336001600160a01b0316826001600160a01b031663f851a4406040518163ffffffff1660e01b8152600401602060405180830381865afa1580156114b1573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906114d591906149ed565b6001600160a01b031614155b156114ff57604051630d03687f60e11b815260040160405180910390fd5b6001600160a01b0382165f9081526082602052604081205463ffffffff169081900361153e576040516374a086a360e01b815260040160405180910390fd5b63ffffffff81165f908152608160205260408120906007820154600160801b900460ff16600281111561157357611573614019565b14611591576040516390db0d0760e01b815260040160405180910390fd5b60068101546001600160401b03908116908416811115806115c9575060068201546001600160401b03600160401b9091048116908516105b156115e75760405163cb23ebdf60e01b815260040160405180910390fd5b805b846001600160401b0316816001600160401b031614611688576001600160401b038082165f908152600385016020526040902060010154600160401b9004811690861681101561164c57604051639753965f60e01b815260040160405180910390fd5b6001600160401b039091165f908152600384016020526040812090815560010180546fffffffffffffffffffffffffffffffff191690556115e9565b60068301805467ffffffffffffffff19166001600160401b0387161790556116b08583614a08565b608480545f906116ca9084906001600160401b0316614a08565b82546101009290920a6001600160401b0381810219909316918316021790915586165f8181526003860160205260409081902054905163334d6f6760e11b8152600481019290925260248201526001600160a01b038816915063669adece906044015f604051808303815f87803b158015611743575f5ffd5b505af1158015611755573d5f5f3e3d5ffd5b505050506001600160401b0385165f81815260038501602090815260409182902054915191825263ffffffff8716917f80a6d395a55aed8126079cb8247f0a6848b1440ca2cdca3b4386f250c3529402910160405180910390a3505050505050565b6040516370a0823160e01b81523060048201525f9081906001600160a01b037f000000000000000000000000000000000000000000000000000000000000000016906370a0823190602401602060405180830381865afa15801561181d573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906118419190614941565b6084549091505f90611865906001600160401b03600160401b820481169116614a08565b6001600160401b03169050805f0361187f575f9250505090565b6118898183614a3b565b9250505090565b606f545f9060ff16156118b657604051630bc011ff60e21b815260040160405180910390fd5b335f9081526082602052604081205463ffffffff16908190036118ec576040516371653c1560e01b815260040160405180910390fd5b836001600160401b03165f0361191557604051632590ccf960e01b815260040160405180910390fd5b63ffffffff81165f908152608160205260408120906007820154600160801b900460ff16600281111561194a5761194a614019565b14611968576040516390db0d0760e01b815260040160405180910390fd5b608480548691905f906119859084906001600160401b031661490b565b82546101009290920a6001600160401b0381810219909316918316021790915560068301541690505f6119b8878361490b565b6006840180546001600160401b0383811667ffffffffffffffff199092168217909255604080516060810182528a815242841660208083019182528886168385019081525f86815260038c018352859020935184559151600193909301805492518716600160401b026fffffffffffffffffffffffffffffffff199093169390961692909217179093555190815291925063ffffffff8616917f1d9f30260051d51d70339da239ea7b080021adcaabfa71c9b0ea339a20cf9a25910160405180910390a29695505050505050565b6080545f9063ffffffff16808203611a9f57505f919050565b5f816001600160401b03811115611ab857611ab8614397565b604051908082528060200260200182016040528015611ae1578160200160208202803683370190505b5090505f5b82811015611b3e5760815f611afc836001614a4e565b63ffffffff1663ffffffff1681526020019081526020015f2060050154828281518110611b2b57611b2b614a61565b6020908102919091010152600101611ae6565b505f60205b83600114611d59575f611b57600286614a75565b611b62600287614a3b565b611b6c9190614a4e565b90505f816001600160401b03811115611b8757611b87614397565b604051908082528060200260200182016040528015611bb0578160200160208202803683370190505b5090505f5b82811015611d0957611bc8600184614a88565b81148015611be05750611bdc600288614a75565b6001145b15611c5d5785611bf182600261492a565b81518110611c0157611c01614a61565b602002602001015185604051602001611c24929190918252602082015260400190565b60405160208183030381529060405280519060200120828281518110611c4c57611c4c614a61565b602002602001018181525050611d01565b85611c6982600261492a565b81518110611c7957611c79614a61565b602002602001015186826002611c8f919061492a565b611c9a906001614a4e565b81518110611caa57611caa614a61565b6020026020010151604051602001611ccc929190918252602082015260400190565b60405160208183030381529060405280519060200120828281518110611cf457611cf4614a61565b6020026020010181815250505b600101611bb5565b508094508195508384604051602001611d2c929190918252602082015260400190565b6040516020818303038152906040528051906020012093508280611d4f90614a9b565b9350505050611b43565b5f835f81518110611d6c57611d6c614a61565b602002602001015190505f5f90505b82811015611de257604080516020810184905290810185905260600160408051601f198184030181528282528051602091820120908301879052908201869052925060600160408051601f1981840301815291905280516020909101209350600101611d7b565b5095945050505050565b7fac75d24dbb35ea80e25fab167da4dea46c1915260426570db84f184891f5f590611e1681612e99565b607e80545f91908290611e2e9063ffffffff16614ab0565b91906101000a81548163ffffffff021916908363ffffffff1602179055905060016002811115611e6057611e60614019565b866002811115611e7257611e72614019565b03611e9b578415611e96576040516363d722e760e01b815260040160405180910390fd5b611f55565b6002866002811115611eaf57611eaf614019565b03611f05576001600160a01b038816151580611ed357506001600160401b03871615155b80611edd57508415155b80611ee757508215155b15611e96576040516363d722e760e01b815260040160405180910390fd5b5f866002811115611f1857611f18614019565b03611f3c578215611e96576040516363d722e760e01b815260040160405180910390fd5b6040516363d722e760e01b815260040160405180910390fd5b6040518060e001604052808a6001600160a01b03168152602001896001600160a01b03168152602001886001600160401b03168152602001876002811115611f9f57611f9f614019565b81525f602080830182905260408084018a9052606093840188905263ffffffff86168352607f825291829020845181546001600160a01b0391821673ffffffffffffffffffffffffffffffffffffffff1990911617825591850151600182018054948701516001600160401b0316600160a01b026001600160e01b031990951691909316179290921780825592840151919260ff60e01b1916600160e01b83600281111561204f5761204f614019565b02179055506080820151600182018054911515600160e81b0260ff60e81b1990921691909117905560a0820151600282015560c09091015160039091015560405163ffffffff8216907f9eaf2ecbddb14889c9e141a63175c55ac25e0cd7cdea312cdfbd0397976b383a906120d1908c908c908c908c908c908c908c90614ad4565b60405180910390a2505050505050505050565b7f66156603fe29d13f97c6f3e3dff4ef71919f9aa61c555be0182d954e94221aac61210e81612e99565b6121198484846136da565b50505050565b7fa0fab074aba36a6fa69f1a83ee86e5abfb8433966eb57efb13dc2fc2f24ddd0861214981612e99565b63ffffffff891615806121675750607e5463ffffffff908116908a16115b1561218557604051637512e5cb60e01b815260040160405180910390fd5b63ffffffff89165f908152607f602052604090206001810154600160e81b900460ff16156121c657604051633b8d3d9960e01b815260040160405180910390fd5b63ffffffff6001600160401b038a1611156121f457604051634c753f5760e01b815260040160405180910390fd5b6001600160401b0389165f9081526083602052604090205463ffffffff1615612230576040516337c8fe0960e11b815260040160405180910390fd5b608080545f919082906122489063ffffffff16614ab0565b825463ffffffff8281166101009490940a93840293021916919091179091558254604080515f80825260208201928390529394506001600160a01b0390921691309161229390613ea0565b61229f93929190614b3a565b604051809103905ff0801580156122b8573d5f5f3e3d5ffd5b5090508160835f8d6001600160401b03166001600160401b031681526020019081526020015f205f6101000a81548163ffffffff021916908363ffffffff1602179055508160825f836001600160a01b03166001600160a01b031681526020019081526020015f205f6101000a81548163ffffffff021916908363ffffffff1602179055505f60815f8463ffffffff1663ffffffff1681526020019081526020015f20905081815f015f6101000a8154816001600160a01b0302191690836001600160a01b031602179055508360010160149054906101000a90046001600160401b03168160010160146101000a8154816001600160401b0302191690836001600160401b03160217905550836001015f9054906101000a90046001600160a01b0316816001015f6101000a8154816001600160a01b0302191690836001600160a01b031602179055508b815f0160146101000a8154816001600160401b0302191690836001600160401b031602179055508360020154816002015f5f6001600160401b031681526020019081526020015f20819055508c63ffffffff168160070160086101000a8154816001600160401b0302191690836001600160401b0316021790555083600101601c9054906101000a900460ff168160070160106101000a81548160ff021916908360028111156124b5576124b5614019565b0217905550836003015481600901819055508263ffffffff167f194c983456df6701c6a50830b90fe80e72b823411d0d524970c9590dc277a6418e848f8d604051612536949392919063ffffffff9490941684526001600160a01b0392831660208501526001600160401b0391909116604084015216606082015260800190565b60405180910390a260026001850154600160e01b900460ff16600281111561256057612560614019565b036125c35760405163439fab9160e01b81526001600160a01b0383169063439fab919061259190899060040161431a565b5f604051808303815f87803b1580156125a8575f5ffd5b505af11580156125ba573d5f5f3e3d5ffd5b50505050612627565b604051633892b81160e11b81526001600160a01b038316906371257022906125f9908e908e9088908f908f908f90600401614b73565b5f604051808303815f87803b158015612610575f5ffd5b505af1158015612622573d5f5f3e3d5ffd5b505050505b50505050505050505050505050565b7f8cf807f6970720f8e2c208c7c5037595982c7bd9ed93c380d09df743d0dcc3fb61266081612e99565b683635c9adc5dea0000082118061267a5750633b9aca0082105b1561269857604051638586952560e01b815260040160405180910390fd5b60868290556040518281527ffb383653f53ee079978d0c9aff7aeff04a10166ce244cca9c9f9d8d96bed45b29060200160405180910390a15050565b5f828152603460205260409020600101546126ee81612e99565b610c4083836132ea565b7f62ba6ba2ffed8cfe316b583325ea41ac6e7ba9e5864d2bc6fabba7ac26d2f0f461272281612e99565b6087805467ffffffffffffffff1916426001600160401b031617905560408051636de0b4bb60e11b815290517f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03169163dbc16976916004808301925f92919082900301818387803b15801561279d575f5ffd5b505af11580156127af573d5f5f3e3d5ffd5b505050506127bb613a6e565b50565b63ffffffff86165f9081526081602052604090206060906112e690889088888888886133d8565b336001600160a01b0316826001600160a01b031663f851a4406040518163ffffffff1660e01b8152600401602060405180830381865afa15801561282b573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061284f91906149ed565b6001600160a01b0316146128765760405163696072e960e01b815260040160405180910390fd5b6001600160a01b0382165f9081526082602090815260408083205463ffffffff1683526081909152902060068101546001600160401b03808216600160401b90920416146128d75760405163664316a560e11b815260040160405180910390fd5b600263ffffffff83165f908152607f6020526040902060010154600160e01b900460ff16600281111561290c5761290c614019565b141580156129355750600781015463ffffffff8316600160401b9091046001600160401b031610155b1561295357604051633e37e23360e01b815260040160405180910390fd5b6001600160a01b0383165f9081526082602090815260408083205463ffffffff8681168552607f909352922060010154911690600160e01b900460ff1660028111156129a1576129a1614019565b63ffffffff82165f908152607f6020526040902060010154600160e01b900460ff1660028111156129d4576129d4614019565b146129f257604051635aa0d5f160e11b815260040160405180910390fd5b604080515f81526020810190915261211990859085906136da565b7f3dfe277d2a2c04b75fb2eb3743fa00005ae3678a20c299e65fdf4df76517f68e612a3781612e99565b6001600160401b0386165f9081526083602052604090205463ffffffff1615612a73576040516337c8fe0960e11b815260040160405180910390fd5b63ffffffff6001600160401b0387161115612aa157604051634c753f5760e01b815260040160405180910390fd5b6001600160a01b0389165f9081526082602052604090205463ffffffff1615612add57604051630d409b9360e41b815260040160405180910390fd5b608080545f91908290612af59063ffffffff16614ab0565b91906101000a81548163ffffffff021916908363ffffffff160217905590508060835f896001600160401b03166001600160401b031681526020019081526020015f205f6101000a81548163ffffffff021916908363ffffffff1602179055508060825f8c6001600160a01b03166001600160a01b031681526020019081526020015f205f6101000a81548163ffffffff021916908363ffffffff1602179055505f60815f8363ffffffff1663ffffffff1681526020019081526020015f2090508a815f015f6101000a8154816001600160a01b0302191690836001600160a01b03160217905550888160010160146101000a8154816001600160401b0302191690836001600160401b0316021790555089816001015f6101000a8154816001600160a01b0302191690836001600160a01b0316021790555087815f0160146101000a8154816001600160401b0302191690836001600160401b03160217905550858160070160106101000a81548160ff02191690836002811115612c7c57612c7c614019565b02179055506001866002811115612c9557612c95614019565b03612cad576009810185905560058101879055612cec565b6002866002811115612cc157612cc1614019565b03612cd9576008810184905560058101879055612cec565b5f80805260028201602052604090208790555b8163ffffffff167f4da47f6e9bbd9ef91887183a576aaebcf1b9bb7d2a567b33b075044c6d36082e8a8d8b8a5f8b8b604051612d2e9796959493929190614bdd565b60405180910390a25050505050505050505050565b612da760408051610180810182525f80825260208201819052918101829052606081018290526080810182905260a0810182905260c0810182905260e081018290526101008101829052610120810182905261014081018290529061016082015290565b63ffffffff82165f9081526081602090815260409182902080546001600160a01b038082168652600160a01b918290046001600160401b03908116948701949094526001830154908116948601949094529092048116606084015260058201546080840152600682015480821660a0850152600160401b808204831660c0860152600160801b808304841660e0870152600160c01b909204831661010086015260078401548084166101208701529081049092166101408501526101608401910460ff166002811115612e7c57612e7c614019565b90816002811115612e8f57612e8f614019565b8152505050919050565b6127bb8133613ac5565b5f5f612ec189600601546001600160401b03600160401b9091041690565b60078a01549091506001600160401b039081169089161015612ef65760405163ead1340b60e01b815260040160405180910390fd5b6001600160401b0388165f90815260028a016020526040902054915081612f30576040516324cbdcc360e11b815260040160405180910390fd5b806001600160401b0316886001600160401b03161115612f6357604051630f2b74f160e11b815260040160405180910390fd5b806001600160401b0316876001600160401b031611612f955760405163b9b18f5760e01b815260040160405180910390fd5b5f612fa48a8a8a8a878b6135d7565b90505f7f30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001600283604051612fd89190614c38565b602060405180830381855afa158015612ff3573d5f5f3e3d5ffd5b5050506040513d601f19601f820116820180604052508101906130169190614941565b6130209190614a75565b60018c0154604080516020810182528381529051634890ed4560e11b81529293506001600160a01b0390911691639121da8a9161306291899190600401614c4e565b602060405180830381865afa15801561307d573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906130a19190614c8a565b6130be576040516309bde33960e01b815260040160405180910390fd5b5f6130c9848b614a08565b905061311c87826001600160401b03166130e16117b7565b6130eb919061492a565b6001600160a01b037f0000000000000000000000000000000000000000000000000000000000000000169190613b07565b80608460088282829054906101000a90046001600160401b0316613140919061490b565b82546101009290920a6001600160401b038181021990931691831602179091556084805467ffffffffffffffff60801b1916600160801b428416021790558d546040516332c2d15360e01b8152918d166004830152602482018b90523360448301526001600160a01b031691506332c2d153906064015f604051808303815f87803b1580156131cd575f5ffd5b505af11580156131df573d5f5f3e3d5ffd5b50505050505050505050505050505050565b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b0316632072f6c56040518163ffffffff1660e01b81526004015f604051808303815f87803b158015613249575f5ffd5b505af115801561325b573d5f5f3e3d5ffd5b50505050610c1a613b6e565b5f8281526034602090815260408083206001600160a01b038516845290915290205460ff16610c78575f8281526034602090815260408083206001600160a01b0385168085529252808320805460ff1916600117905551339285917f2f8788117e7eff1d82e926ec794901d17c78024a50270940304540a733656f0d9190a45050565b5f8281526034602090815260408083206001600160a01b038516845290915290205460ff1615610c78575f8281526034602090815260408083206001600160a01b0385168085529252808320805460ff1916905551339285917ff6391f5c32d9c69d2a47ea670b442974b53935d1edc7fd64eb21e047a839171b9190a45050565b7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005c156133ab57604051633ee5aeb560e01b815260040160405180910390fd5b610c1a60017f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f005b90613bc9565b606060026007880154600160801b900460ff1660028111156133fc576133fc614019565b036134d7578654604051631a957d9b60e21b81525f916001600160a01b031690636a55f66c9061343290879087906004016149da565b602060405180830381865afa15801561344d573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906134719190614941565b600589015460088a0154604080516020810193909352820152606081018990526001600160e01b031960e08c901b1660808201526084810182905260a4810188905260c4810187905290915060e4016040516020818303038152906040529150506112e6565b865460408051632b47b7cd60e21b815290515f926001600160a01b03169163ad1edf349160048083019260209291908290030181865afa15801561351d573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906135419190614941565b600589015460088a0154604080516020810193909352820152606081018990526001600160e01b031960e08c901b1660808201526084810182905260a4810188905260c4810187905290915060e401604051602081830303815290604052915050979650505050505050565b610c1a5f7f9b779b17422d0df92223018b32b4d1fa46e071723d6817e2486d003becc55f006133d2565b6001600160401b038086165f818152600389016020526040808220549388168252902054606092911580159061360b575081155b156136295760405163340c614f60e11b815260040160405180910390fd5b80613647576040516366385b5160e01b815260040160405180910390fd5b61365084613bd0565b61366d576040516305dae44f60e21b815260040160405180910390fd5b3385838a8c5f0160149054906101000a90046001600160401b03168d60010160149054906101000a90046001600160401b031689878d8f6040516020016136bd9a99989796959493929190614ca9565b604051602081830303815290604052925050509695505050505050565b63ffffffff821615806136f85750607e5463ffffffff908116908316115b1561371657604051637512e5cb60e01b815260040160405180910390fd5b6001600160a01b0383165f9081526082602052604081205463ffffffff1690819003613755576040516374a086a360e01b815260040160405180910390fd5b63ffffffff8181165f908152608160205260409020600781015490918516600160401b9091046001600160401b0316036137a257604051634f61d51960e01b815260040160405180910390fd5b63ffffffff84165f908152607f602052604090206001810154600160e81b900460ff16156137e357604051633b8d3d9960e01b815260040160405180910390fd5b60026001820154600160e01b900460ff16600281111561380557613805614019565b146138a85760026007830154600160801b900460ff16600281111561382c5761382c614019565b0361384a57604051635aa0d5f160e11b815260040160405180910390fd5b6001810154600160e01b900460ff16600281111561386a5761386a614019565b6007830154600160801b900460ff16600281111561388a5761388a614019565b146138a857604051635aa0d5f160e11b815260040160405180910390fd5b60018082018054918401805473ffffffffffffffffffffffffffffffffffffffff1981166001600160a01b03909416938417825582546001600160401b03600160a01b9182900416026001600160e01b03199091169093179290921790915560038201546009840155600783018054600160401b63ffffffff8916026fffffffffffffffff000000000000000019821681178355925460ff600160e01b909104169270ff00000000000000000000000000000000191670ffffffffffffffffff00000000000000001990911617600160801b83600281111561398c5761398c614019565b02179055505f61399b8461093a565b60078401805467ffffffffffffffff19166001600160401b038316179055825460405163278f794360e11b81529192506001600160a01b0389811692634f1ef286926139ed9216908990600401614d5d565b5f604051808303815f87803b158015613a04575f5ffd5b505af1158015613a16573d5f5f3e3d5ffd5b50506040805163ffffffff8a811682526001600160401b0386166020830152881693507ff585e04c05d396901170247783d3e5f0ee9c1df23072985b50af089f5e48b19d92500160405180910390a250505050505050565b606f5460ff16613a9157604051635386698160e01b815260040160405180910390fd5b606f805460ff191690556040517f1e5e34eea33501aecf2ebec9fe0e884a40804275ea7fe10b2ba084c8374308b3905f90a1565b5f8281526034602090815260408083206001600160a01b038516845290915290205460ff16610c7857604051637615be1f60e11b815260040160405180910390fd5b604080516001600160a01b038416602482015260448082018490528251808303909101815260649091019091526020810180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff1663a9059cbb60e01b179052610c40908490613c55565b606f5460ff1615613b9257604051630bc011ff60e21b815260040160405180910390fd5b606f805460ff191660011790556040517f2261efe5aef6fedc1fd1550b25facc9181745623049c7901287030b9ad1a5497905f90a1565b80825d5050565b5f67ffffffff000000016001600160401b038316108015613c05575067ffffffff00000001604083901c6001600160401b0316105b8015613c25575067ffffffff00000001608083901c6001600160401b0316105b8015613c3c575067ffffffff0000000160c083901c105b15613c4957506001919050565b505f919050565b919050565b5f613ca9826040518060400160405280602081526020017f5361666545524332303a206c6f772d6c6576656c2063616c6c206661696c6564815250856001600160a01b0316613d269092919063ffffffff16565b805190915015610c405780806020019051810190613cc79190614c8a565b610c405760405162461bcd60e51b815260206004820152602a60248201527f5361666545524332303a204552433230206f7065726174696f6e20646964206e6044820152691bdd081cdd58d8d9595960b21b606482015260840161137f565b6060613d3484845f85613d3c565b949350505050565b606082471015613d9d5760405162461bcd60e51b815260206004820152602660248201527f416464726573733a20696e73756666696369656e742062616c616e636520666f6044820152651c8818d85b1b60d21b606482015260840161137f565b5f5f866001600160a01b03168587604051613db89190614c38565b5f6040518083038185875af1925050503d805f8114613df2576040519150601f19603f3d011682016040523d82523d5f602084013e613df7565b606091505b50915091506112e68783838760608315613e715782515f03613e6a576001600160a01b0385163b613e6a5760405162461bcd60e51b815260206004820152601d60248201527f416464726573733a2063616c6c20746f206e6f6e2d636f6e7472616374000000604482015260640161137f565b5081613d34565b613d348383815115613e865781518083602001fd5b8060405162461bcd60e51b815260040161137f919061431a565b6108b080614d7f83390190565b803563ffffffff81168114613c50575f5ffd5b5f60208284031215613ed0575f5ffd5b613ed982613ead565b9392505050565b80356001600160401b0381168114613c50575f5ffd5b6001600160a01b03811681146127bb575f5ffd5b8035613c5081613ef6565b5f5f5f5f5f5f5f5f6103e0898b031215613f2d575f5ffd5b613f3689613ead565b9750613f4460208a01613ee0565b9650613f5260408a01613ee0565b9550613f6060608a01613ee0565b94506080890135935060a0890135925060c0890135613f7e81613ef6565b91506103e089018a1015613f90575f5ffd5b60e0890190509295985092959890939650565b5f60208284031215613fb3575f5ffd5b5035919050565b5f5f60408385031215613fcb575f5ffd5b613fd483613ead565b9150613fe260208401613ee0565b90509250929050565b5f5f60408385031215613ffc575f5ffd5b82359150602083013561400e81613ef6565b809150509250929050565b634e487b7160e01b5f52602160045260245ffd5b6003811061404957634e487b7160e01b5f52602160045260245ffd5b9052565b6001600160a01b038881168252871660208201526001600160401b038616604082015260e08101614081606083018761402d565b931515608082015260a081019290925260c090910152949350505050565b5f5f83601f8401126140af575f5ffd5b5081356001600160401b038111156140c5575f5ffd5b6020830191508360208285010111156140dc575f5ffd5b9250929050565b5f5f5f5f5f5f5f5f60c0898b0312156140fa575f5ffd5b61410389613ead565b975061411160208a01613ead565b9650604089013595506060890135945060808901356001600160401b03811115614139575f5ffd5b6141458b828c0161409f565b90955093505060a08901356001600160401b03811115614163575f5ffd5b61416f8b828c0161409f565b999c989b5096995094979396929594505050565b81516001600160a01b03168152610180810160208301516141af60208401826001600160401b03169052565b5060408301516141ca60408401826001600160a01b03169052565b5060608301516141e560608401826001600160401b03169052565b506080830151608083015260a083015161420a60a08401826001600160401b03169052565b5060c083015161422560c08401826001600160401b03169052565b5060e083015161424060e08401826001600160401b03169052565b5061010083015161425d6101008401826001600160401b03169052565b5061012083015161427261012084018261402d565b5061014083015161014083015261016083015161016083015292915050565b5f5f5f5f5f5f60c087890312156142a6575f5ffd5b6142af87613ead565b95506142bd60208801613ee0565b94506142cb60408801613ee0565b959894975094956060810135955060808101359460a0909101359350915050565b5f81518084528060208401602086015e5f602082860101526020601f19601f83011685010191505092915050565b602081525f613ed960208301846142ec565b5f6020828403121561433c575f5ffd5b613ed982613ee0565b5f5f60408385031215614356575f5ffd5b8235613fd481613ef6565b5f5f60408385031215614372575f5ffd5b61437b83613ee0565b946020939093013593505050565b803560038110613c50575f5ffd5b634e487b7160e01b5f52604160045260245ffd5b5f82601f8301126143ba575f5ffd5b8135602083015f5f6001600160401b038411156143d9576143d9614397565b50604051601f19601f85018116603f011681018181106001600160401b038211171561440757614407614397565b60405283815290508082840187101561441e575f5ffd5b838360208301375f602085830101528094505050505092915050565b5f5f5f5f5f5f5f60e0888a031215614450575f5ffd5b873561445b81613ef6565b9650602088013561446b81613ef6565b955061447960408901613ee0565b945061448760608901614389565b93506080880135925060a08801356001600160401b038111156144a8575f5ffd5b6144b48a828b016143ab565b979a969950949793969295929450505060c09091013590565b5f5f5f606084860312156144df575f5ffd5b83356144ea81613ef6565b92506144f860208501613ead565b915060408401356001600160401b03811115614512575f5ffd5b61451e868287016143ab565b9150509250925092565b5f5f5f5f5f5f5f5f610100898b031215614540575f5ffd5b61454989613ead565b975061455760208a01613ee0565b965061456560408a01613f0a565b955061457360608a01613f0a565b945061458160808a01613f0a565b935060a08901356001600160401b0381111561459b575f5ffd5b6145a78b828c016143ab565b93505060c08901356001600160401b038111156145c2575f5ffd5b6145ce8b828c016143ab565b92505060e08901356001600160401b038111156145e9575f5ffd5b6145f58b828c016143ab565b9150509295985092959890939650565b5f60208284031215614615575f5ffd5b8135613ed981613ef6565b5f5f5f5f5f5f60a08789031215614635575f5ffd5b61463e87613ead565b955060208701359450604087013593506060870135925060808701356001600160401b0381111561466d575f5ffd5b61467989828a0161409f565b979a9699509497509295939492505050565b5f5f6040838503121561469c575f5ffd5b82356146a781613ef6565b9150613fe260208401613ead565b6001600160a01b038d811682526001600160401b038d81166020840152908c1660408301528a81166060830152608082018a905288811660a0830152871660c082015261018081016001600160401b03871660e08301526001600160401b03861661010083015261472a61012083018661402d565b61014082019390935261016001529a9950505050505050505050565b5f5f5f5f5f5f5f5f610100898b03121561475e575f5ffd5b883561476981613ef6565b9750602089013561477981613ef6565b965061478760408a01613ee0565b955061479560608a01613ee0565b9450608089013593506147aa60a08a01614389565b979a969950949793969295929450505060c08201359160e0013590565b81516001600160a01b03168152610180810160208301516147f360208401826001600160401b03169052565b50604083015161480e60408401826001600160a01b03169052565b50606083015161482960608401826001600160401b03169052565b506080830151608083015260a083015161484e60a08401826001600160401b03169052565b5060c083015161486960c08401826001600160401b03169052565b5060e083015161488460e08401826001600160401b03169052565b506101008301516148a16101008401826001600160401b03169052565b506101208301516148be6101208401826001600160401b03169052565b506101408301516148db6101408401826001600160401b03169052565b506101608301516148f061016084018261402d565b5092915050565b634e487b7160e01b5f52601160045260245ffd5b6001600160401b038181168382160190811115610963576109636148f7565b8082028115828204841417610963576109636148f7565b5f60208284031215614951575f5ffd5b5051919050565b81835281816020850137505f828201602090810191909152601f909101601f19169091010190565b604081525f61499260408301866142ec565b82810360208401526149a5818587614958565b9695505050505050565b848152606060208201525f6149c760608301866142ec565b82810360408401526112e6818587614958565b602081525f613d34602083018486614958565b5f602082840312156149fd575f5ffd5b8151613ed981613ef6565b6001600160401b038281168282160390811115610963576109636148f7565b634e487b7160e01b5f52601260045260245ffd5b5f82614a4957614a49614a27565b500490565b80820180821115610963576109636148f7565b634e487b7160e01b5f52603260045260245ffd5b5f82614a8357614a83614a27565b500690565b81810381811115610963576109636148f7565b5f81614aa957614aa96148f7565b505f190190565b5f63ffffffff821663ffffffff8103614acb57614acb6148f7565b60010192915050565b6001600160a01b03881681526001600160a01b03871660208201526001600160401b0386166040820152614b0b606082018661402d565b83608082015260e060a08201525f614b2660e08301856142ec565b90508260c083015298975050505050505050565b6001600160a01b03841681526001600160a01b0383166020820152606060408201525f614b6a60608301846142ec565b95945050505050565b6001600160a01b03871681526001600160a01b038616602082015263ffffffff851660408201526001600160a01b038416606082015260c060808201525f614bbe60c08301856142ec565b82810360a0840152614bd081856142ec565b9998505050505050505050565b6001600160401b0388811682526001600160a01b03881660208301528616604082015260e08101614c11606083018761402d565b6001600160401b03851660808301528360a08301528260c083015298975050505050505050565b5f82518060208501845e5f920191825250919050565b61032081016103008483376103008201835f5b6001811015614c80578151835260209283019290910190600101614c61565b5050509392505050565b5f60208284031215614c9a575f5ffd5b81518015158114613ed9575f5ffd5b6bffffffffffffffffffffffff198b60601b1681528960148201528860348201526001600160401b0360c01b8860c01b1660548201526001600160401b0360c01b8760c01b16605c8201526001600160401b0360c01b8660c01b16606482015284606c82015283608c8201528260ac820152614d4c60cc82018360c01b7fffffffffffffffff000000000000000000000000000000000000000000000000169052565b60d4019a9950505050505050505050565b6001600160a01b0383168152604060208201525f613d3460408301846142ec56fe60a06040526040516108b03803806108b083398101604081905261002291610327565b828161002e8282610056565b50506001600160a01b03821660805261004e61004960805190565b6100b4565b50505061040e565b61005f82610121565b6040516001600160a01b038316907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b905f90a28051156100a8576100a3828261019f565b505050565b6100b0610212565b5050565b7f7e644d79422f17c01e4894b5f4f588d331ebfa28653d42ae832dc59e38c9798f6100f35f5160206108905f395f51905f52546001600160a01b031690565b604080516001600160a01b03928316815291841660208301520160405180910390a161011e81610233565b50565b806001600160a01b03163b5f0361015b57604051634c9c8ce360e01b81526001600160a01b03821660048201526024015b60405180910390fd5b807f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc5b80546001600160a01b0319166001600160a01b039290921691909117905550565b60605f5f846001600160a01b0316846040516101bb91906103f8565b5f60405180830381855af49150503d805f81146101f3576040519150601f19603f3d011682016040523d82523d5f602084013e6101f8565b606091505b509092509050610209858383610270565b95945050505050565b34156102315760405163b398979f60e01b815260040160405180910390fd5b565b6001600160a01b03811661025c57604051633173bdd160e11b81525f6004820152602401610152565b805f5160206108905f395f51905f5261017e565b60608261028557610280826102cf565b6102c8565b815115801561029c57506001600160a01b0384163b155b156102c557604051639996b31560e01b81526001600160a01b0385166004820152602401610152565b50805b9392505050565b8051156102df5780518082602001fd5b604051630a12f52160e11b815260040160405180910390fd5b80516001600160a01b038116811461030e575f5ffd5b919050565b634e487b7160e01b5f52604160045260245ffd5b5f5f5f60608486031215610339575f5ffd5b610342846102f8565b9250610350602085016102f8565b60408501519092506001600160401b0381111561036b575f5ffd5b8401601f8101861361037b575f5ffd5b80516001600160401b0381111561039457610394610313565b604051601f8201601f19908116603f011681016001600160401b03811182821017156103c2576103c2610313565b6040528181528282016020018810156103d9575f5ffd5b8160208401602083015e5f602083830101528093505050509250925092565b5f82518060208501845e5f920191825250919050565b60805161046b6104255f395f6010015261046b5ff3fe608060405261000c61000e565b005b7f00000000000000000000000000000000000000000000000000000000000000006001600160a01b03163303610081575f357fffffffff000000000000000000000000000000000000000000000000000000001663278f794360e11b1461007957610077610085565b565b610077610095565b6100775b6100776100906100c3565b6100fa565b5f806100a43660048184610313565b8101906100b1919061034e565b915091506100bf8282610118565b5050565b5f6100f57f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc546001600160a01b031690565b905090565b365f5f375f5f365f845af43d5f5f3e808015610114573d5ff35b3d5ffd5b61012182610172565b6040516001600160a01b038316907fbc7cd75a20ee27fd9adebab32041f755214dbc6bffa90cc0225b39da2e5c2d3b905f90a280511561016a5761016582826101fa565b505050565b6100bf61026c565b806001600160a01b03163b5f036101ac57604051634c9c8ce360e01b81526001600160a01b03821660048201526024015b60405180910390fd5b7f360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc805473ffffffffffffffffffffffffffffffffffffffff19166001600160a01b0392909216919091179055565b60605f5f846001600160a01b031684604051610216919061041f565b5f60405180830381855af49150503d805f811461024e576040519150601f19603f3d011682016040523d82523d5f602084013e610253565b606091505b509150915061026385838361028b565b95945050505050565b34156100775760405163b398979f60e01b815260040160405180910390fd5b6060826102a05761029b826102ea565b6102e3565b81511580156102b757506001600160a01b0384163b155b156102e057604051639996b31560e01b81526001600160a01b03851660048201526024016101a3565b50805b9392505050565b8051156102fa5780518082602001fd5b604051630a12f52160e11b815260040160405180910390fd5b5f5f85851115610321575f5ffd5b8386111561032d575f5ffd5b5050820193919092039150565b634e487b7160e01b5f52604160045260245ffd5b5f5f6040838503121561035f575f5ffd5b82356001600160a01b0381168114610375575f5ffd5b9150602083013567ffffffffffffffff811115610390575f5ffd5b8301601f810185136103a0575f5ffd5b803567ffffffffffffffff8111156103ba576103ba61033a565b604051601f8201601f19908116603f0116810167ffffffffffffffff811182821017156103e9576103e961033a565b604052818152828201602001871015610400575f5ffd5b816020840160208301375f602083830101528093505050509250929050565b5f82518060208501845e5f92019182525091905056fea2646970667358221220f0c40b8d0bc55a45013a71ee3fd7264ce873fcc561d04a41ba1f24adbcef958c64736f6c634300081c0033b53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103a26469706673582212203a3c88f208edab75cb7577e66ab98dc612d1c8038cb4bdfda5cc5cf947a1d89164736f6c634300081c0033",
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/crates/aggchain-proof-contracts/src/config.rs
+++ b/crates/aggchain-proof-contracts/src/config.rs
@@ -1,0 +1,46 @@
+use alloy::primitives::{address, Address};
+use prover_utils::from_env_or_default;
+use serde::{Deserialize, Serialize};
+
+/// Address of the `GlobalExitRootManagerL2SovereignChain.sol` contract
+/// on the L2 chain is always fixed.
+const GLOBAL_EXIT_ROOT_MANAGER_L2_SOVEREIGN_CHAIN_ADDRESS: Address =
+    address!("0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA");
+
+/// Address of the `PolygonRollupManager.sol` contract
+/// on the L1 chain.
+const POLYGON_ROLLUP_MANAGER: Address = address!("0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e");
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub struct AggchainProofContractsConfig {
+    #[serde(alias = "PolygonRollupManagerContract")]
+    pub polygon_rollup_manager_contract: Address,
+    #[serde(alias = "GlobalExitRootManagerL2SovereignChainContract")]
+    pub global_exit_root_manager_v2_sovereign_chain: Address,
+}
+
+impl Default for AggchainProofContractsConfig {
+    fn default() -> Self {
+        Self {
+            polygon_rollup_manager_contract: default_polygon_rollup_manager(),
+            global_exit_root_manager_v2_sovereign_chain:
+                default_global_exit_root_manager_v2_sovereign_chain(),
+        }
+    }
+}
+
+pub(crate) fn default_output_at_block_endpoint() -> String {
+    from_env_or_default(
+        "L2_OUTPUT_AT_BLOCK_ENDPOINT",
+        "l2_outputAtBlock".to_string(),
+    )
+}
+
+fn default_polygon_rollup_manager() -> Address {
+    POLYGON_ROLLUP_MANAGER
+}
+
+fn default_global_exit_root_manager_v2_sovereign_chain() -> Address {
+    GLOBAL_EXIT_ROOT_MANAGER_L2_SOVEREIGN_CHAIN_ADDRESS
+}

--- a/crates/aggchain-proof-contracts/src/config.rs
+++ b/crates/aggchain-proof-contracts/src/config.rs
@@ -14,17 +14,19 @@ const POLYGON_ROLLUP_MANAGER: Address = address!("0xB7f8BC63BbcaD18155201308C8f3
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct AggchainProofContractsConfig {
-    #[serde(alias = "PolygonRollupManagerContract")]
+    /// Address of the L1 PolygonRollupManager.sol contract
+    #[serde(default = "default_polygon_rollup_manager")]
     pub polygon_rollup_manager_contract: Address,
-    #[serde(alias = "GlobalExitRootManagerL2SovereignChainContract")]
-    pub global_exit_root_manager_v2_sovereign_chain: Address,
+    /// Address of the L2 GlobalExitRootManagerL2SovereignChain.sol contract
+    #[serde(default = "default_global_exit_root_manager_v2_sovereign_chain")]
+    pub global_exit_root_manager_v2_sovereign_chain_contract: Address,
 }
 
 impl Default for AggchainProofContractsConfig {
     fn default() -> Self {
         Self {
             polygon_rollup_manager_contract: default_polygon_rollup_manager(),
-            global_exit_root_manager_v2_sovereign_chain:
+            global_exit_root_manager_v2_sovereign_chain_contract:
                 default_global_exit_root_manager_v2_sovereign_chain(),
         }
     }

--- a/crates/aggchain-proof-contracts/src/config.rs
+++ b/crates/aggchain-proof-contracts/src/config.rs
@@ -16,17 +16,17 @@ const POLYGON_ROLLUP_MANAGER: Address = address!("0xB7f8BC63BbcaD18155201308C8f3
 pub struct AggchainProofContractsConfig {
     /// Address of the L1 PolygonRollupManager.sol contract
     #[serde(default = "default_polygon_rollup_manager")]
-    pub polygon_rollup_manager_contract: Address,
+    pub polygon_rollup_manager: Address,
     /// Address of the L2 GlobalExitRootManagerL2SovereignChain.sol contract
     #[serde(default = "default_global_exit_root_manager_v2_sovereign_chain")]
-    pub global_exit_root_manager_v2_sovereign_chain_contract: Address,
+    pub global_exit_root_manager_v2_sovereign_chain: Address,
 }
 
 impl Default for AggchainProofContractsConfig {
     fn default() -> Self {
         Self {
-            polygon_rollup_manager_contract: default_polygon_rollup_manager(),
-            global_exit_root_manager_v2_sovereign_chain_contract:
+            polygon_rollup_manager: default_polygon_rollup_manager(),
+            global_exit_root_manager_v2_sovereign_chain:
                 default_global_exit_root_manager_v2_sovereign_chain(),
         }
     }

--- a/crates/aggchain-proof-contracts/src/config.rs
+++ b/crates/aggchain-proof-contracts/src/config.rs
@@ -1,6 +1,7 @@
 use alloy::primitives::{address, Address};
 use prover_utils::from_env_or_default;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 /// Address of the `GlobalExitRootManagerL2SovereignChain.sol` contract
 /// on the L2 chain is always fixed.
@@ -14,6 +15,18 @@ const POLYGON_ROLLUP_MANAGER: Address = address!("0xB7f8BC63BbcaD18155201308C8f3
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "kebab-case")]
 pub struct AggchainProofContractsConfig {
+    /// JSON-RPC endpoint of the l1 node.
+    #[serde(default = "prover_alloy::default_l1_node_url")]
+    pub l1_rpc_endpoint: Url,
+
+    /// JSON-RPC endpoint of the l2 execution node.
+    #[serde(default = "prover_alloy::default_l2_execution_layer_url")]
+    pub l2_execution_layer_rpc_endpoint: Url,
+
+    /// JSON-RPC endpoint of the l2 rollup node.
+    #[serde(default = "prover_alloy::default_l2_consensus_layer_url")]
+    pub l2_consensus_layer_rpc_endpoint: Url,
+
     /// Address of the L1 PolygonRollupManager.sol contract
     #[serde(default = "default_polygon_rollup_manager")]
     pub polygon_rollup_manager: Address,
@@ -25,6 +38,9 @@ pub struct AggchainProofContractsConfig {
 impl Default for AggchainProofContractsConfig {
     fn default() -> Self {
         Self {
+            l1_rpc_endpoint: prover_alloy::default_l1_node_url(),
+            l2_execution_layer_rpc_endpoint: prover_alloy::default_l2_execution_layer_url(),
+            l2_consensus_layer_rpc_endpoint: prover_alloy::default_l2_consensus_layer_url(),
             polygon_rollup_manager: default_polygon_rollup_manager(),
             global_exit_root_manager_v2_sovereign_chain:
                 default_global_exit_root_manager_v2_sovereign_chain(),

--- a/crates/aggchain-proof-contracts/src/contracts.rs
+++ b/crates/aggchain-proof-contracts/src/contracts.rs
@@ -53,7 +53,6 @@ pub trait L2LocalExitRootFetcher {
 
 #[async_trait::async_trait]
 pub trait L2OutputAtBlockFetcher {
-    fn parse_l2_output_root(json: serde_json::Value) -> Result<L2OutputAtBlock, Error>;
     async fn get_l2_output_at_block(&self, block_number: u64) -> Result<L2OutputAtBlock, Error>;
 }
 

--- a/crates/aggchain-proof-contracts/src/contracts.rs
+++ b/crates/aggchain-proof-contracts/src/contracts.rs
@@ -1,0 +1,73 @@
+use aggchain_proof_core::Digest;
+use alloy::network::Ethereum;
+use alloy::primitives::B256;
+use alloy::sol;
+
+use crate::Error;
+
+sol!(
+    #[allow(missing_docs)]
+    #[allow(clippy::too_many_arguments)]
+    #[sol(rpc)]
+    GlobalExitRootManagerL2SovereignChain,
+    "contracts/global-exit-root-manager-l2-sovereign-chain.json"
+);
+
+sol!(
+    #[allow(missing_docs)]
+    #[allow(clippy::too_many_arguments)]
+    #[sol(rpc)]
+    PolygonZkevmBridgeV2,
+    "contracts/polygon-zkevm-bridge-v2.json"
+);
+
+sol!(
+    #[allow(missing_docs)]
+    #[allow(clippy::too_many_arguments)]
+    #[sol(rpc)]
+    PolygonRollupManager,
+    "contracts/polygon-rollup-manager.json"
+);
+
+sol!(
+    #[allow(missing_docs)]
+    #[allow(clippy::too_many_arguments)]
+    #[sol(rpc)]
+    AggchainFep,
+    "contracts/aggchain-fep.json"
+);
+
+pub(crate) type ZkevmBridgeRpcClient<RpcProvider> =
+    PolygonZkevmBridgeV2::PolygonZkevmBridgeV2Instance<(), RpcProvider, Ethereum>;
+
+pub(crate) type PolygonRollupManagerRpcClient<RpcProvider> =
+    PolygonRollupManager::PolygonRollupManagerInstance<(), RpcProvider, Ethereum>;
+
+pub(crate) type AggchainFepRpcClient<RpcProvider> =
+    AggchainFep::AggchainFepInstance<(), RpcProvider, Ethereum>;
+
+#[async_trait::async_trait]
+pub trait L2LocalExitRootFetcher {
+    async fn get_l2_local_exit_root(&self, block_number: u64) -> Result<Digest, Error>;
+}
+
+#[async_trait::async_trait]
+pub trait L2OutputAtBlockFetcher {
+    fn parse_l2_output_root(json: serde_json::Value) -> Result<L2OutputAtBlock, Error>;
+    async fn get_l2_output_at_block(&self, block_number: u64) -> Result<L2OutputAtBlock, Error>;
+}
+
+#[async_trait::async_trait]
+pub trait L1RollupConfigHashFetcher {
+    async fn get_rollup_config_hash(&self) -> Result<Digest, Error>;
+}
+
+/// L2 output at block data structure.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct L2OutputAtBlock {
+    pub version: B256,
+    pub state_root: Digest,
+    pub withdrawal_storage_root: Digest,
+    pub latest_block_hash: Digest,
+    pub output_root: Digest,
+}

--- a/crates/aggchain-proof-contracts/src/error.rs
+++ b/crates/aggchain-proof-contracts/src/error.rs
@@ -15,6 +15,9 @@ pub enum Error {
     #[error("Unable to retrieve zkevm bridge address from the global exit root manager contract")]
     BridgeAddressError(#[source] alloy::contract::Error),
 
+    #[error("Unable to retrieve aggchain fep address from the polygon rollup manager contract")]
+    AggchainFepAddressError(#[source] alloy::contract::Error),
+
     #[error("Error retrieving local exit root")]
     LocalExitRootError(#[source] alloy::contract::Error),
 

--- a/crates/aggchain-proof-contracts/src/error.rs
+++ b/crates/aggchain-proof-contracts/src/error.rs
@@ -12,7 +12,7 @@ pub enum Error {
     #[error("Invalid contract address")]
     InvalidContractAddress(#[source] alloy::hex::FromHexError),
 
-    #[error("Unable to retrieve bridge address from the global exit root manager contract")]
+    #[error("Unable to retrieve zkevm bridge address from the global exit root manager contract")]
     BridgeAddressError(#[source] alloy::contract::Error),
 
     #[error("Error retrieving local exit root")]
@@ -20,4 +20,22 @@ pub enum Error {
 
     #[error("Unable to setup async engine")]
     AsyncEngineSetupError(#[source] std::io::Error),
+
+    #[error("Unable to create HTTP RPC rollup node client")]
+    RollupNodeInitError(#[source] jsonrpsee::core::ClientError),
+
+    #[error("Error retrieving l2 output at block from the node")]
+    L2OutputAtBlockRetrievalError(#[source] jsonrpsee::core::ClientError),
+
+    #[error("L2 output at block value is missing, field {0}")]
+    L2OutputAtBlockValueMissing(String),
+
+    #[error("Invalid L2 output at block, field {0}")]
+    L2OutputAtBlockInvalidValue(String, #[source] alloy::hex::FromHexError),
+
+    #[error("Error performing rollup manager rollup id to rollup data call")]
+    InvalidRollupIdToRollupData(#[source] alloy::contract::Error),
+
+    #[error("Error retrieving rollup config hash")]
+    RollupConfigHashError(#[source] alloy::contract::Error),
 }

--- a/crates/aggchain-proof-contracts/src/lib.rs
+++ b/crates/aggchain-proof-contracts/src/lib.rs
@@ -27,15 +27,6 @@ pub use crate::error::Error;
 pub trait AggchainContractsClient:
     L2LocalExitRootFetcher + L2OutputAtBlockFetcher + L1RollupConfigHashFetcher
 {
-    fn new(
-        l1_rpc_endpoint: &Url,
-        l2_el_rpc_endpoint: &Url,
-        l2_cl_rpc_endpoint: &Url,
-        network_id: u32,
-        contracts: &AggchainProofContractsConfig,
-    ) -> Result<Self, Error>
-    where
-        Self: std::marker::Sized;
 }
 
 /// `AggchainProofContractsRpcClient` is a client for interacting with the
@@ -57,6 +48,8 @@ pub struct AggchainContractsRpcClient<RpcProvider> {
     /// Aggchain FEP contract on the l1 network.
     aggchain_fep: AggchainFepRpcClient<RpcProvider>,
 }
+
+impl<T: alloy::providers::Provider> AggchainContractsClient for AggchainContractsRpcClient<T> {}
 
 #[async_trait::async_trait]
 impl<RpcProvider> L2LocalExitRootFetcher for AggchainContractsRpcClient<RpcProvider>
@@ -135,8 +128,8 @@ where
     }
 }
 
-impl AggchainContractsClient for AggchainContractsRpcClient<AlloyFillProvider> {
-    fn new(
+impl AggchainContractsRpcClient<AlloyFillProvider> {
+    pub fn new(
         l1_rpc_endpoint: &Url,
         l2_el_rpc_endpoint: &Url,
         l2_cl_rpc_endpoint: &Url,

--- a/crates/aggchain-proof-contracts/src/lib.rs
+++ b/crates/aggchain-proof-contracts/src/lib.rs
@@ -163,7 +163,7 @@ impl AggchainContractsRpcClient<AlloyFillProvider> {
 
         // Create client for global exit root manager smart contract.
         let global_exit_root_manager_l2 = GlobalExitRootManagerL2SovereignChain::new(
-            contracts.global_exit_root_manager_v2_sovereign_chain,
+            contracts.global_exit_root_manager_v2_sovereign_chain_contract,
             l2_el_client.clone(),
         );
 
@@ -206,7 +206,7 @@ impl AggchainContractsRpcClient<AlloyFillProvider> {
         // Create client for AggchainFep smart contract.
         let aggchain_fep = AggchainFep::new(aggchain_fep_address, l1_client.clone());
 
-        info!(global_exit_root_manager_l2=%contracts.global_exit_root_manager_v2_sovereign_chain,
+        info!(global_exit_root_manager_l2=%contracts.global_exit_root_manager_v2_sovereign_chain_contract,
             polygon_zkevm_bridge_v2=%polygon_zkevm_bridge_v2.address(),
             polygon_rollup_manager=%contracts.polygon_rollup_manager_contract,
             aggchain_fep=%aggchain_fep.address(),

--- a/crates/aggchain-proof-contracts/src/lib.rs
+++ b/crates/aggchain-proof-contracts/src/lib.rs
@@ -1,95 +1,188 @@
+pub mod config;
+pub mod contracts;
 mod error;
 
+use std::str::FromStr;
 use std::sync::Arc;
 
-use alloy::network::Ethereum;
-use alloy::primitives::Address;
-use alloy::primitives::{address, B256};
-use alloy::sol;
-use prover_alloy::{AlloyFillProvider, AlloyProvider};
+use aggchain_proof_core::Digest;
+use alloy::primitives::B256;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::http_client::HttpClient;
+use jsonrpsee::rpc_params;
+use prover_alloy::{build_alloy_fill_provider, AlloyFillProvider};
 use tracing::info;
 use url::Url;
 
+use crate::config::AggchainProofContractsConfig;
+use crate::contracts::{
+    AggchainFep, AggchainFepRpcClient, GlobalExitRootManagerL2SovereignChain,
+    L1RollupConfigHashFetcher, L2LocalExitRootFetcher, L2OutputAtBlock, L2OutputAtBlockFetcher,
+    PolygonRollupManagerRpcClient, PolygonZkevmBridgeV2, ZkevmBridgeRpcClient,
+};
 pub use crate::error::Error;
 
-/// Address of the `GlobalExitRootManagerL2SovereignChain.sol` contract
-/// on the L2 chain is always fixed.
-const GLOBAL_EXIT_ROOT_MANAGER_L2_SOVEREIGN_CHAIN_ADDRESS: Address =
-    address!("0xa40D5f56745a118D0906a34E69aeC8C0Db1cB8fA");
-
-sol!(
-    #[allow(missing_docs)]
-    #[allow(clippy::too_many_arguments)]
-    #[sol(rpc)]
-    GlobalExitRootManagerL2SovereignChain,
-    "contracts/global-exit-root-manager-l2-sovereign-chain.json"
-);
-
-sol!(
-    #[allow(missing_docs)]
-    #[allow(clippy::too_many_arguments)]
-    #[sol(rpc)]
-    PolygonZkevmBridgeV2,
-    "contracts/polygon-zkevm-bridge-v2.json"
-);
-
-type GlobalExitRootManagerClient =
-    GlobalExitRootManagerL2SovereignChain::GlobalExitRootManagerL2SovereignChainInstance<
-        (),
-        AlloyFillProvider,
-        Ethereum,
-    >;
-type ZkevmBridgeClient =
-    PolygonZkevmBridgeV2::PolygonZkevmBridgeV2Instance<(), AlloyFillProvider, Ethereum>;
-
-/// `AggchainProofContractsClient` is a client for interacting with the
-/// smart contracts relevant for the aggchain prover.
-#[derive(Clone)]
-pub struct AggchainProofContractsClient {
-    /// Mainnet node rpc client.
-    _l1_client: Arc<AlloyProvider>,
-
-    /// L2 node rpc client.
-    _l2_client: Arc<AlloyProvider>,
-
-    /// Global exit root manager for smart sovereign chain
-    /// contract on the l2 network.
-    _global_exit_root_manager_l2: GlobalExitRootManagerClient,
-
-    /// Polygon zkevm bridge contract on the l2 network.
-    polygon_zkevm_bridge_v2: ZkevmBridgeClient,
+/// `AggchainContractsClient` is a trait for interacting with the smart
+/// contracts relevant for the aggchain prover.
+pub trait AggchainContractsClient:
+    L2LocalExitRootFetcher + L2OutputAtBlockFetcher + L1RollupConfigHashFetcher
+{
+    fn new(
+        l1_rpc_endpoint: &Url,
+        l2_el_rpc_endpoint: &Url,
+        l2_cl_rpc_endpoint: &Url,
+        network_id: u32,
+        contracts: &AggchainProofContractsConfig,
+    ) -> Result<Self, Error>
+    where
+        Self: std::marker::Sized;
 }
 
-impl AggchainProofContractsClient {
-    pub fn new(l1_rpc_endpoint: &Url, l2_rpc_endpoint: &Url) -> Result<Self, crate::Error> {
-        let l1_client = Arc::new(
-            AlloyProvider::new(
-                l1_rpc_endpoint,
-                prover_alloy::DEFAULT_HTTP_RPC_NODE_INITIAL_BACKOFF_MS,
-                prover_alloy::DEFAULT_HTTP_RPC_NODE_BACKOFF_MAX_RETRIES,
-            )
-            .map_err(Error::ProviderInitializationError)?,
-        );
+/// `AggchainProofContractsRpcClient` is a client for interacting with the
+/// smart contracts relevant for the aggchain prover.
+#[derive(Clone)]
+pub struct AggchainContractsRpcClient<RpcProvider> {
+    /// Mainnet node rpc client.
+    _l1_client: Arc<RpcProvider>,
 
-        let l2_client = Arc::new(
-            AlloyProvider::new(
-                l2_rpc_endpoint,
-                prover_alloy::DEFAULT_HTTP_RPC_NODE_INITIAL_BACKOFF_MS,
-                prover_alloy::DEFAULT_HTTP_RPC_NODE_BACKOFF_MAX_RETRIES,
-            )
-            .map_err(Error::ProviderInitializationError)?,
+    /// L2 rpc execution layer client.
+    _l2_el_client: Arc<RpcProvider>,
+
+    /// L2 rpc consensus layer client (rollup node).
+    l2_cl_client: Arc<HttpClient>,
+
+    /// Polygon zkevm bridge contract on the l2 network.
+    polygon_zkevm_bridge_v2: ZkevmBridgeRpcClient<RpcProvider>,
+
+    /// Aggchain FEP contract on the l1 network.
+    aggchain_fep: AggchainFepRpcClient<RpcProvider>,
+}
+
+#[async_trait::async_trait]
+impl<RpcProvider> L2LocalExitRootFetcher for AggchainContractsRpcClient<RpcProvider>
+where
+    RpcProvider: alloy::providers::Provider + Send + Sync,
+{
+    async fn get_l2_local_exit_root(&self, block_number: u64) -> Result<Digest, Error> {
+        let response = self
+            .polygon_zkevm_bridge_v2
+            .getRoot()
+            .call_raw()
+            .block(block_number.into())
+            .await
+            .map_err(Error::LocalExitRootError)?;
+
+        let result = self
+            .polygon_zkevm_bridge_v2
+            .getRoot()
+            .decode_output(response, true)
+            .map_err(Error::LocalExitRootError)?;
+
+        Ok(*result._0)
+    }
+}
+
+#[async_trait::async_trait]
+impl<RpcProvider> L2OutputAtBlockFetcher for AggchainContractsRpcClient<RpcProvider>
+where
+    RpcProvider: alloy::providers::Provider + Send + Sync,
+{
+    fn parse_l2_output_root(json: serde_json::Value) -> Result<L2OutputAtBlock, Error> {
+        fn parse_field(json: &serde_json::Value, field: &str) -> Result<B256, Error> {
+            let value_str = json
+                .get(field)
+                .ok_or(Error::L2OutputAtBlockValueMissing(field.to_string()))?
+                .as_str()
+                .ok_or(Error::L2OutputAtBlockValueMissing(field.to_string()))?;
+
+            B256::from_str(value_str)
+                .map_err(|e| Error::L2OutputAtBlockInvalidValue(field.to_string(), e))
+        }
+
+        let block_ref = json
+            .get("blockRef")
+            .ok_or(Error::L2OutputAtBlockValueMissing("blockRef".to_string()))?;
+
+        Ok(L2OutputAtBlock {
+            version: parse_field(&json, "version")?,
+            state_root: *parse_field(&json, "stateRoot")?,
+            withdrawal_storage_root: *parse_field(&json, "withdrawalStorageRoot")?,
+            latest_block_hash: *parse_field(block_ref, "hash")?,
+            output_root: *parse_field(&json, "outputRoot")?,
+        })
+    }
+
+    async fn get_l2_output_at_block(&self, block_number: u64) -> Result<L2OutputAtBlock, Error> {
+        let params = rpc_params![format!("0x{block_number:x}")];
+        let json: serde_json::Value = self
+            .l2_cl_client
+            .request(&crate::config::default_output_at_block_endpoint(), params)
+            .await
+            .map_err(Error::L2OutputAtBlockRetrievalError)?;
+
+        Self::parse_l2_output_root(json)
+    }
+}
+
+#[async_trait::async_trait]
+impl<RpcProvider> L1RollupConfigHashFetcher for AggchainContractsRpcClient<RpcProvider>
+where
+    RpcProvider: alloy::providers::Provider + Send + Sync,
+{
+    async fn get_rollup_config_hash(&self) -> Result<Digest, Error> {
+        let response = self
+            .aggchain_fep
+            .chainConfigHash()
+            .call_raw()
+            .await
+            .map_err(Error::RollupConfigHashError)?;
+
+        let chain_config_hash_response = self
+            .aggchain_fep
+            .chainConfigHash()
+            .decode_output(response, true)
+            .map_err(Error::RollupConfigHashError)?;
+        Ok(*chain_config_hash_response._0)
+    }
+}
+
+impl AggchainContractsClient for AggchainContractsRpcClient<AlloyFillProvider> {
+    fn new(
+        l1_rpc_endpoint: &Url,
+        l2_el_rpc_endpoint: &Url,
+        l2_cl_rpc_endpoint: &Url,
+        network_id: u32,
+        contracts: &AggchainProofContractsConfig,
+    ) -> Result<Self, crate::Error> {
+        let l1_client = build_alloy_fill_provider(
+            l1_rpc_endpoint,
+            prover_alloy::DEFAULT_HTTP_RPC_NODE_INITIAL_BACKOFF_MS,
+            prover_alloy::DEFAULT_HTTP_RPC_NODE_BACKOFF_MAX_RETRIES,
+        )
+        .map_err(Error::ProviderInitializationError)?;
+
+        let l2_el_client = build_alloy_fill_provider(
+            l2_el_rpc_endpoint,
+            prover_alloy::DEFAULT_HTTP_RPC_NODE_INITIAL_BACKOFF_MS,
+            prover_alloy::DEFAULT_HTTP_RPC_NODE_BACKOFF_MAX_RETRIES,
+        )
+        .map_err(Error::ProviderInitializationError)?;
+
+        let l2_cl_client = Arc::new(
+            HttpClient::builder()
+                .build(l2_cl_rpc_endpoint)
+                .map_err(Error::RollupNodeInitError)?,
         );
 
         // Create client for global exit root manager smart contract.
         let global_exit_root_manager_l2 = GlobalExitRootManagerL2SovereignChain::new(
-            GLOBAL_EXIT_ROOT_MANAGER_L2_SOVEREIGN_CHAIN_ADDRESS,
-            l2_client.provider().clone(),
+            contracts.global_exit_root_manager_v2_sovereign_chain,
+            l2_el_client.clone(),
         );
 
         // Retrieve PolygonZkEVMBridgeV2 contract address from the global exit root
         // manager contract.
         let polygon_zkevm_bridge_address = {
-            let global_exit_root_manager_l2 = global_exit_root_manager_l2.clone();
             tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -103,38 +196,89 @@ impl AggchainProofContractsClient {
         .map_err(Error::BridgeAddressError)?;
 
         // Create client for Polygon zkevm bridge v2 smart contract.
-        let polygon_zkevm_bridge_v2 = PolygonZkevmBridgeV2::new(
-            polygon_zkevm_bridge_address._0,
-            l2_client.provider().clone(),
+        let polygon_zkevm_bridge_v2 =
+            PolygonZkevmBridgeV2::new(polygon_zkevm_bridge_address._0, l2_el_client.clone());
+
+        // Create client for Polygon rollup manager contract.
+        let polygon_rollup_manager = PolygonRollupManagerRpcClient::new(
+            contracts.polygon_rollup_manager_contract,
+            l1_client.clone(),
         );
 
-        info!(global_exit_root_manager_l2=%GLOBAL_EXIT_ROOT_MANAGER_L2_SOVEREIGN_CHAIN_ADDRESS,
+        // Retrieve AggchainFep address from the Polygon rollup manager contract.
+        let aggchain_fep_address = {
+            let polygon_rollup_manager = polygon_rollup_manager.clone();
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(Error::AsyncEngineSetupError)?
+                .block_on(async move {
+                    // We need to retrieve AggchainFep contract address from the
+                    // polygon rollup manager.
+                    let rollup_data = polygon_rollup_manager
+                        .rollupIDToRollupData(network_id)
+                        .call()
+                        .await?;
+                    Ok(rollup_data.rollupData.rollupContract)
+                })
+        }
+        .map_err(Error::BridgeAddressError)?;
+
+        // Create client for AggchainFep smart contract.
+        let aggchain_fep = AggchainFep::new(aggchain_fep_address, l1_client.clone());
+
+        info!(global_exit_root_manager_l2=%contracts.global_exit_root_manager_v2_sovereign_chain,
             polygon_zkevm_bridge_v2=%polygon_zkevm_bridge_v2.address(),
+            polygon_rollup_manager=%contracts.polygon_rollup_manager_contract,
+            aggchain_fep=%aggchain_fep.address(),
             "Aggchain proof contracts client created successfully");
 
         Ok(Self {
-            _l1_client: l1_client,
-            _l2_client: l2_client,
-            _global_exit_root_manager_l2: global_exit_root_manager_l2,
+            _l1_client: Arc::new(l1_client),
+            _l2_el_client: Arc::new(l2_el_client),
+            l2_cl_client,
             polygon_zkevm_bridge_v2,
+            aggchain_fep,
         })
     }
+}
 
-    pub async fn get_l2_local_exit_root(&self, block_number: u64) -> Result<B256, Error> {
-        let bytes = self
-            .polygon_zkevm_bridge_v2
-            .getRoot()
-            .call_raw()
-            .block(block_number.into())
-            .await
-            .map_err(Error::LocalExitRootError)?;
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
 
-        let result = self
-            .polygon_zkevm_bridge_v2
-            .getRoot()
-            .decode_output(bytes, true)
-            .map_err(Error::LocalExitRootError)?;
+    use alloy::primitives::B256;
+    use prover_alloy::AlloyFillProvider;
 
-        Ok(result._0)
+    use crate::contracts::L2OutputAtBlockFetcher;
+    use crate::AggchainContractsRpcClient;
+
+    #[test]
+    fn parsing_l2_output_root() -> Result<(), Box<dyn std::error::Error>> {
+        let json_str = r#"{"version":"0x0000000000000000000000000000000000000000000000000000000000000000",
+        "outputRoot":"0xf9758545eb67c1a90276b44bb80047fa72148f88c69a8653f36cd157f537bde4",
+        "blockRef":{"hash":"0x2d0d159b47e89cd85b82c18d217fa47f5901e81e71ae80356854849656b43354","number":16, "parentHash":"0xa64a3a659538ce9fa247ddcd83a6ce51442de0047e5a01aa6c11833493819831","timestamp":1740413570,
+        "l1origin":{"hash":"0xa3a945dcb7f80f558631917e37e7b633fb430347a303a025b944bdfdc5f4c5a3","number":13},"sequenceNumber":8},
+        "withdrawalStorageRoot":"0x8ed4baae3a927be3dea54996b4d5899f8c01e7594bf50b17dc1e741388ce3d12",
+        "stateRoot":"0x965938f5738ae8c501d7de25f61597ea2a76ea2802fc535233eb427376b43328",
+        "syncStatus":{"current_l1":{"hash":"0x62735836100c2257429e9cfb80250b5d0df29d0ea9c6bcf0f6da8c2a355115d8","number":29,"parentHash":"0xb036ae96aabc83a1b43ced9de73f4e8b8288cdffcbfbcc29a62ae015ec2d696c","timestamp":1740413646},"current_l1_finalized":{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","number":0,"parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","timestamp":0},"head_l1":{"hash":"0x907f61e597d733f603350f7a9eae4a2b444ebda317460f3d67e8d2e3eb53466c","number":30,"parentHash":"0x62735836100c2257429e9cfb80250b5d0df29d0ea9c6bcf0f6da8c2a355115d8","timestamp":1740413652},"safe_l1":{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","number":0,"parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","timestamp":0},"finalized_l1":{"hash":"0x0000000000000000000000000000000000000000000000000000000000000000","number":0,"parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","timestamp":0},"unsafe_l2":{"hash":"0x04cc3d231feefa1685bf2ddf192085b72caf80901b2b96416af107347d66c493","number":59,"parentHash":"0x6521911591fd0cada5e864361a84b6bdd6619b4103011c1cab34b07488041d05","timestamp":1740413656,"l1origin":{"hash":"0xe35ebcb9669083f8b1c54be0b4b073ea620b5419d9cbcdbce808b21ba1f1a577","number":27},"sequenceNumber":0},"safe_l2":{"hash":"0x049bbccee5391aee272fe5a90e8243b0af5cef59bbf0fb971cb62314d9149780","number":41,"parentHash":"0xd47dff00fd82e599635eac5139ddea0070d57cd1111be64c604db8cc64f2396b","timestamp":1740413620,"l1origin":{"hash":"0xdb22ab9cb1619cd14f3e9092c7729faf0efa711afcc7f5440b44d5ea6263239e","number":21},"sequenceNumber":0},"finalized_l2":{"hash":"0x0dc6c55aa95cce979b62983736b1ca066560db65bac8efbb4050ddb412b4ad8c","number":0,"parentHash":"0x0000000000000000000000000000000000000000000000000000000000000000","timestamp":1740413538,"l1origin":{"hash":"0x12ec696bd1cb110f89513b620071935f09460ee6a81fea25fc2f400ea816bb7b","number":11},"sequenceNumber":0},"pending_safe_l2":{"hash":"0x049bbccee5391aee272fe5a90e8243b0af5cef59bbf0fb971cb62314d9149780","number":41,"parentHash":"0xd47dff00fd82e599635eac5139ddea0070d57cd1111be64c604db8cc64f2396b","timestamp":1740413620,"l1origin":{"hash":"0xdb22ab9cb1619cd14f3e9092c7729faf0efa711afcc7f5440b44d5ea6263239e","number":21},"sequenceNumber":0},"cross_unsafe_l2":{"hash":"0x04cc3d231feefa1685bf2ddf192085b72caf80901b2b96416af107347d66c493","number":59,"parentHash":"0x6521911591fd0cada5e864361a84b6bdd6619b4103011c1cab34b07488041d05","timestamp":1740413656,"l1origin":{"hash":"0xe35ebcb9669083f8b1c54be0b4b073ea620b5419d9cbcdbce808b21ba1f1a577","number":27},"sequenceNumber":0},"local_safe_l2":{"hash":"0x049bbccee5391aee272fe5a90e8243b0af5cef59bbf0fb971cb62314d9149780","number":41,"parentHash":"0xd47dff00fd82e599635eac5139ddea0070d57cd1111be64c604db8cc64f2396b","timestamp":1740413620,
+        "l1origin":{"hash":"0xdb22ab9cb1619cd14f3e9092c7729faf0efa711afcc7f5440b44d5ea6263239e","number":21},"sequenceNumber":0}}}"#;
+        let result = AggchainContractsRpcClient::<AlloyFillProvider>::parse_l2_output_root(
+            serde_json::from_str(json_str).unwrap(),
+        )?;
+
+        assert_eq!(result.version, B256::default());
+        assert_eq!(
+            result.latest_block_hash,
+            B256::from_str("0x2d0d159b47e89cd85b82c18d217fa47f5901e81e71ae80356854849656b43354")
+                .unwrap()
+        );
+        assert_eq!(
+            result.output_root,
+            B256::from_str("0xf9758545eb67c1a90276b44bb80047fa72148f88c69a8653f36cd157f537bde4")
+                .unwrap()
+        );
+
+        Ok(())
     }
 }

--- a/crates/aggchain-proof-contracts/src/lib.rs
+++ b/crates/aggchain-proof-contracts/src/lib.rs
@@ -67,18 +67,12 @@ where
         let response = self
             .polygon_zkevm_bridge_v2
             .getRoot()
-            .call_raw()
+            .call()
             .block(block_number.into())
             .await
             .map_err(Error::LocalExitRootError)?;
 
-        let result = self
-            .polygon_zkevm_bridge_v2
-            .getRoot()
-            .decode_output(response, true)
-            .map_err(Error::LocalExitRootError)?;
-
-        Ok(*result._0)
+        Ok(*response._0)
     }
 }
 
@@ -88,7 +82,7 @@ where
     RpcProvider: alloy::providers::Provider + Send + Sync,
 {
     fn parse_l2_output_root(json: serde_json::Value) -> Result<L2OutputAtBlock, Error> {
-        fn parse_field(json: &serde_json::Value, field: &str) -> Result<B256, Error> {
+        fn parse_hash(json: &serde_json::Value, field: &str) -> Result<B256, Error> {
             let value_str = json
                 .get(field)
                 .ok_or(Error::L2OutputAtBlockValueMissing(field.to_string()))?
@@ -104,11 +98,11 @@ where
             .ok_or(Error::L2OutputAtBlockValueMissing("blockRef".to_string()))?;
 
         Ok(L2OutputAtBlock {
-            version: parse_field(&json, "version")?,
-            state_root: *parse_field(&json, "stateRoot")?,
-            withdrawal_storage_root: *parse_field(&json, "withdrawalStorageRoot")?,
-            latest_block_hash: *parse_field(block_ref, "hash")?,
-            output_root: *parse_field(&json, "outputRoot")?,
+            version: parse_hash(&json, "version")?,
+            state_root: *parse_hash(&json, "stateRoot")?,
+            withdrawal_storage_root: *parse_hash(&json, "withdrawalStorageRoot")?,
+            latest_block_hash: *parse_hash(block_ref, "hash")?,
+            output_root: *parse_hash(&json, "outputRoot")?,
         })
     }
 
@@ -133,16 +127,11 @@ where
         let response = self
             .aggchain_fep
             .chainConfigHash()
-            .call_raw()
+            .call()
             .await
             .map_err(Error::RollupConfigHashError)?;
 
-        let chain_config_hash_response = self
-            .aggchain_fep
-            .chainConfigHash()
-            .decode_output(response, true)
-            .map_err(Error::RollupConfigHashError)?;
-        Ok(*chain_config_hash_response._0)
+        Ok(*response._0)
     }
 }
 

--- a/crates/aggchain-proof-core/src/lib.rs
+++ b/crates/aggchain-proof-core/src/lib.rs
@@ -2,3 +2,5 @@ mod digest;
 pub mod error;
 mod full_execution_proof;
 pub mod proof;
+
+pub use digest::Digest;

--- a/crates/aggchain-proof-service/src/service.rs
+++ b/crates/aggchain-proof-service/src/service.rs
@@ -81,7 +81,7 @@ pub struct AggchainProofService {
 }
 
 impl AggchainProofService {
-    pub fn new(config: &AggchainProofServiceConfig) -> Result<Self, Error> {
+    pub async fn new(config: &AggchainProofServiceConfig) -> Result<Self, Error> {
         let client = prover_alloy::AlloyProvider::new(
             &config.proposer_service.l1_rpc_endpoint,
             prover_alloy::DEFAULT_HTTP_RPC_NODE_INITIAL_BACKOFF_MS,
@@ -100,7 +100,8 @@ impl AggchainProofService {
         let aggchain_proof_builder = tower::ServiceBuilder::new()
             .service(
                 AggchainProofBuilder::new(&config.aggchain_proof_builder)
-                    .map_err(Error::AggchainProofBuilderInitFailed)?,
+                    .map_err(Error::AggchainProofBuilderInitFailed)
+                    .await?,
             )
             .boxed_clone();
 

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -17,8 +17,8 @@ runtime-timeout = "5s"
 
 [aggchain-proof-service.aggchain-proof-builder]
 l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"
-l2-el-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
-l2-cl-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
+l2-execution-layer-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
+l2-consensus-layer-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
 network-id = 0
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -17,7 +17,8 @@ runtime-timeout = "5s"
 
 [aggchain-proof-service.aggchain-proof-builder]
 l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"
-l2-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
+l2-el-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
+l2-cl-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
 network-id = 0
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]
@@ -26,6 +27,10 @@ proving-timeout = "5m"
 [aggchain-proof-service.aggchain-proof-builder.proving-timeout]
 secs = 3600
 nanos = 0
+
+[aggchain-proof-service.aggchain-proof-builder.contracts]
+polygon-rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+global-exit-root-manager-v2-sovereign-chain = "0xa40d5f56745a118d0906a34e69aec8c0db1cb8fa"
 
 [aggchain-proof-service.proposer-service]
 l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -16,9 +16,6 @@ prometheus-addr = "0.0.0.0:3001"
 runtime-timeout = "5s"
 
 [aggchain-proof-service.aggchain-proof-builder]
-l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"
-l2-execution-layer-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
-l2-consensus-layer-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
 network-id = 0
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]
@@ -29,6 +26,9 @@ secs = 3600
 nanos = 0
 
 [aggchain-proof-service.aggchain-proof-builder.contracts]
+l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"
+l2-execution-layer-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
+l2-consensus-layer-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
 polygon-rollup-manager = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
 global-exit-root-manager-v2-sovereign-chain = "0xa40d5f56745a118d0906a34e69aec8c0db1cb8fa"
 

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -29,7 +29,7 @@ secs = 3600
 nanos = 0
 
 [aggchain-proof-service.aggchain-proof-builder.contracts]
-polygon-rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+polygon-rollup-manager = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
 global-exit-root-manager-v2-sovereign-chain = "0xa40d5f56745a118d0906a34e69aec8c0db1cb8fa"
 
 [aggchain-proof-service.proposer-service]

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
@@ -32,7 +32,7 @@ secs = 3600
 nanos = 0
 
 [aggchain-proof-service.aggchain-proof-builder.contracts]
-polygon-rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+polygon-rollup-manager = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
 global-exit-root-manager-v2-sovereign-chain = "0xa40d5f56745a118d0906a34e69aec8c0db1cb8fa"
 
 [aggchain-proof-service.proposer-service]

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
@@ -20,8 +20,8 @@ runtime-timeout = "5s"
 
 [aggchain-proof-service.aggchain-proof-builder]
 l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"
-l2-el-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
-l2-cl-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
+l2-execution-layer-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
+l2-consensus-layer-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
 network-id = 0
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
@@ -20,7 +20,8 @@ runtime-timeout = "5s"
 
 [aggchain-proof-service.aggchain-proof-builder]
 l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"
-l2-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
+l2-el-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
+l2-cl-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
 network-id = 0
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]
@@ -29,6 +30,10 @@ proving-timeout = "5m"
 [aggchain-proof-service.aggchain-proof-builder.proving-timeout]
 secs = 3600
 nanos = 0
+
+[aggchain-proof-service.aggchain-proof-builder.contracts]
+polygon-rollup-manager-contract = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
+global-exit-root-manager-v2-sovereign-chain = "0xa40d5f56745a118d0906a34e69aec8c0db1cb8fa"
 
 [aggchain-proof-service.proposer-service]
 l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
@@ -19,9 +19,6 @@ prometheus-addr = "0.0.0.0:3001"
 runtime-timeout = "5s"
 
 [aggchain-proof-service.aggchain-proof-builder]
-l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"
-l2-execution-layer-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
-l2-consensus-layer-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
 network-id = 0
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]
@@ -32,6 +29,9 @@ secs = 3600
 nanos = 0
 
 [aggchain-proof-service.aggchain-proof-builder.contracts]
+l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"
+l2-execution-layer-rpc-endpoint = "http://anvil-mock-l2-rpc:8545/"
+l2-consensus-layer-rpc-endpoint = "http://rollup-node-mock-l2-rpc:8545/"
 polygon-rollup-manager = "0xb7f8bc63bbcad18155201308c8f3540b07f84f5e"
 global-exit-root-manager-v2-sovereign-chain = "0xa40d5f56745a118d0906a34e69aec8c0db1cb8fa"
 

--- a/crates/aggkit-prover/src/main.rs
+++ b/crates/aggkit-prover/src/main.rs
@@ -27,13 +27,12 @@ fn main() -> anyhow::Result<()> {
         .enable_all()
         .build()?;
 
-    let aggchain_proof_service: AggchainProofServiceServer<GrpcService> =
-        prover_runtime.block_on(async {
-            let grpc_service = GrpcService::new(&config.aggchain_proof_service).await?;
-            Ok::<AggchainProofServiceServer<GrpcService>, aggchain_proof_service::Error>(
-                AggchainProofServiceServer::new(grpc_service),
-            )
-        })?;
+    let aggchain_proof_service = prover_runtime.block_on(async {
+        let grpc_service = GrpcService::new(&config.aggchain_proof_service).await?;
+        Ok::<AggchainProofServiceServer<GrpcService>, aggchain_proof_service::Error>(
+            AggchainProofServiceServer::new(grpc_service),
+        )
+    })?;
 
     _ = ProverEngine::builder()
         .add_rpc_service(aggchain_proof_service)

--- a/crates/aggkit-prover/src/main.rs
+++ b/crates/aggkit-prover/src/main.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use aggkit_prover::rpc::GrpcService;
 use aggkit_prover_types::v1::aggchain_proof_service_server::AggchainProofServiceServer;
 use prover_engine::ProverEngine;
 use tokio_util::sync::CancellationToken;
@@ -26,10 +27,13 @@ fn main() -> anyhow::Result<()> {
         .enable_all()
         .build()?;
 
-    // TODO: implement the aggchain-proof service
-    let aggchain_proof_service = AggchainProofServiceServer::new(
-        aggkit_prover::rpc::GrpcService::new(&config.aggchain_proof_service)?,
-    );
+    let aggchain_proof_service: AggchainProofServiceServer<GrpcService> =
+        prover_runtime.block_on(async {
+            let grpc_service = GrpcService::new(&config.aggchain_proof_service).await?;
+            Ok::<AggchainProofServiceServer<GrpcService>, aggchain_proof_service::Error>(
+                AggchainProofServiceServer::new(grpc_service),
+            )
+        })?;
 
     _ = ProverEngine::builder()
         .add_rpc_service(aggchain_proof_service)

--- a/crates/aggkit-prover/src/rpc.rs
+++ b/crates/aggkit-prover/src/rpc.rs
@@ -20,11 +20,13 @@ pub struct GrpcService {
 }
 
 impl GrpcService {
-    pub fn new(config: &AggchainProofServiceConfig) -> Result<Self, aggchain_proof_service::Error> {
+    pub async fn new(
+        config: &AggchainProofServiceConfig,
+    ) -> Result<Self, aggchain_proof_service::Error> {
         Ok(GrpcService {
             service: tower::ServiceBuilder::new()
                 .buffer(MAX_CONCURRENT_REQUESTS)
-                .service(AggchainProofService::new(config)?),
+                .service(AggchainProofService::new(config).await?),
         })
     }
 }

--- a/crates/aggkit-prover/src/tests/mod.rs
+++ b/crates/aggkit-prover/src/tests/mod.rs
@@ -22,7 +22,8 @@ async fn service_can_be_called() {
         "0xaabbccddff000000000000000000000000000000000000000000000000000000",
     );
     let mut service = AggchainProofService::new(&AggchainProofServiceConfig::default())
-        .expect("create aggchain proof");
+        .await
+        .expect("create aggchain proof service");
     let request = AggchainProofServiceRequest {
         start_block: 0,
         max_block: 100,
@@ -42,8 +43,9 @@ async fn testing_rpc_failure() {
 
     let (client, server) = tokio::io::duplex(1024);
 
-    let service =
-        GrpcService::new(&AggchainProofServiceConfig::default()).expect("create grpc service");
+    let service = GrpcService::new(&AggchainProofServiceConfig::default())
+        .await
+        .expect("create grpc service");
 
     tokio::spawn(async move {
         Server::builder()

--- a/crates/proposer-client/Cargo.toml
+++ b/crates/proposer-client/Cargo.toml
@@ -10,9 +10,9 @@ workspace = true
 [dependencies]
 alloy-primitives.workspace = true
 anyhow.workspace = true
-async-trait = { workspace = true }
+async-trait.workspace = true
 hex.workspace = true
-jsonrpsee = { workspace = true }
+jsonrpsee.workspace = true
 reqwest = { workspace = true, features = ["json"]}
 serde.workspace = true
 serde_with = { workspace = true, features = ["hex"] }

--- a/crates/proposer-service/src/config.rs
+++ b/crates/proposer-service/src/config.rs
@@ -8,7 +8,7 @@ pub struct ProposerServiceConfig {
     pub client: ProposerClientConfig,
 
     /// JSON-RPC endpoint of the l1 node.
-    #[serde(default = "prover_alloy::default_l1_url")]
+    #[serde(default = "prover_alloy::default_l1_node_url")]
     pub l1_rpc_endpoint: Url,
 }
 
@@ -16,7 +16,7 @@ impl Default for ProposerServiceConfig {
     fn default() -> Self {
         Self {
             client: ProposerClientConfig::default(),
-            l1_rpc_endpoint: prover_alloy::default_l1_url(),
+            l1_rpc_endpoint: prover_alloy::default_l1_node_url(),
         }
     }
 }

--- a/crates/prover-alloy/src/lib.rs
+++ b/crates/prover-alloy/src/lib.rs
@@ -1,20 +1,18 @@
 use std::str::FromStr as _;
 use std::time::Duration;
 
+use alloy::network::primitives::BlockTransactionsKind;
 use alloy::network::Ethereum;
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
 };
 use alloy::providers::Identity;
+use alloy::providers::{Provider as _, ProviderBuilder};
 use alloy::transports::http::reqwest;
 use alloy::transports::layers::RetryBackoffLayer;
-pub use alloy::*;
 use alloy::{providers::RootProvider, rpc::client::ClientBuilder};
 pub use async_trait::async_trait;
-use providers::{Provider as _, ProviderBuilder};
 use url::Url;
-
-use crate::network::primitives::BlockTransactionsKind;
 
 const HTTP_CLIENT_CONNECTION_POOL_IDLE_TIMEOUT: u64 = 90;
 const HTTP_CLIENT_MAX_IDLE_CONNECTIONS_PER_HOST: usize = 64;
@@ -29,6 +27,28 @@ pub type AlloyFillProvider = FillProvider<
     RootProvider,
     Ethereum,
 >;
+
+pub fn build_alloy_fill_provider(
+    rpc_url: &url::Url,
+    backoff: u64,
+    max_retries: u32,
+) -> Result<AlloyFillProvider, anyhow::Error> {
+    let retry_policy = RetryBackoffLayer::new(max_retries, backoff, 5);
+    let reqwest_client = reqwest::ClientBuilder::new()
+        .pool_max_idle_per_host(HTTP_CLIENT_MAX_IDLE_CONNECTIONS_PER_HOST)
+        .pool_idle_timeout(Duration::from_secs(
+            HTTP_CLIENT_CONNECTION_POOL_IDLE_TIMEOUT,
+        ))
+        .build()?;
+
+    let http = alloy::transports::http::Http::with_client(reqwest_client, rpc_url.clone());
+    let is_local = http.guess_local();
+    let client = ClientBuilder::default()
+        .layer(retry_policy)
+        .transport(http, is_local);
+
+    Ok(ProviderBuilder::new().on_client(client))
+}
 
 #[async_trait]
 #[cfg_attr(feature = "testutils", mockall::automock)]
@@ -96,10 +116,14 @@ impl Provider for AlloyProvider {
     }
 }
 
-pub fn default_l1_url() -> Url {
+pub fn default_l1_node_url() -> Url {
     Url::from_str("http://anvil-mock-l1-rpc:8545").unwrap()
 }
 
-pub fn default_l2_url() -> Url {
+pub fn default_l2_execution_layer_url() -> Url {
     Url::from_str("http://anvil-mock-l2-rpc:8545").unwrap()
+}
+
+pub fn default_l2_consensus_layer_url() -> Url {
+    Url::from_str("http://rollup-node-mock-l2-rpc:8545").unwrap()
 }


### PR DESCRIPTION
# Description

Introduces generic `AggchainContractsClient` used by the `aggchain-proof-builder` to retrieve public inputs from the chain smart contracts.

In this PR implemented are retrieval of the `l2_pre_root` and the `claim_root` and their pre-image data. It also retrieves rollup config hash from the `AggchainFep` l1 contract.

Fixes #46
Fixes #47

Note:
Additional client for the l2 rollup node is also added.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
