### PR TITLE
feat: add remaining constraints in aggchain proof

### DIFF
--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -9,7 +9,8 @@ use aggchain_proof_contracts::contracts::{
     L1RollupConfigHashFetcher, L2LocalExitRootFetcher, L2OutputAtBlockFetcher,
 };
 use aggchain_proof_contracts::{AggchainContractsClient, AggchainContractsRpcClient};
-use aggchain_proof_core::proof::{AggchainProofWitness, InclusionProof, L1InfoTreeLeaf};
+use aggchain_proof_core::proof::AggchainProofWitness;
+use aggkit_prover_types::v1::{InclusionProof, L1InfoTreeLeaf};
 use aggkit_prover_types::Hash;
 pub use error::Error;
 use futures::{future::BoxFuture, FutureExt};

--- a/crates/aggchain-proof-core/src/bridge/inserted_ger.rs
+++ b/crates/aggchain-proof-core/src/bridge/inserted_ger.rs
@@ -19,9 +19,9 @@ impl L1InfoTreeLeaf {
 /// Contents of one leaf of the L1 Info Tree.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct L1InfoTreeLeaf {
-    pub(crate) global_exit_root: Digest,
-    pub(crate) block_hash: Digest,
-    pub(crate) timestamp: u64,
+    pub global_exit_root: Digest,
+    pub block_hash: Digest,
+    pub timestamp: u64,
 }
 
 /// Data to verify the legitimacy of one inserted GER.

--- a/crates/aggchain-proof-core/src/bridge/mod.rs
+++ b/crates/aggchain-proof-core/src/bridge/mod.rs
@@ -1,15 +1,14 @@
 //! A program that verifies the bridge integrity
 use alloy_primitives::{address, Address};
 use alloy_sol_macro::sol;
+use inserted_ger::InsertedGER;
 use serde::{Deserialize, Serialize};
 use sp1_cc_client_executor::io::EVMStateSketch;
 use static_call::{execute_static_call, StaticCallError, StaticCallStage};
 
-use crate::bridge::inserted_ger::InsertedGER;
-use crate::keccak::digest::Digest;
-use crate::keccak::keccak256_combine;
+use crate::{keccak::keccak256_combine, Digest};
 
-mod inserted_ger;
+pub(crate) mod inserted_ger;
 mod static_call;
 
 /// NOTE: Won't work with Outpost networks as this address won't be constant.

--- a/crates/aggchain-proof-core/src/bridge/mod.rs
+++ b/crates/aggchain-proof-core/src/bridge/mod.rs
@@ -82,10 +82,21 @@ impl BridgeConstraintsError {
 /// Bridge data required to verify the BridgeConstraintsInput integrity.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BridgeWitness {
+    /// List of inserted GER.
     pub inserted_gers: Vec<InsertedGER>,
-    pub prev_hash_chain_sketch: EVMStateSketch,
-    pub new_hash_chain_sketch: EVMStateSketch,
-    pub get_bridge_address_sketch: EVMStateSketch,
+    /// List of the hash of the global index of each imported bridge exit.
+    pub global_index_hashes: Vec<Digest>,
+    /// State sketch to retrieve the previous hash chain GER.
+    pub prev_hash_chain_ger_sketch: EVMStateSketch,
+    /// State sketch to retrieve the new hash chain GER.
+    pub new_hash_chain_ger_sketch: EVMStateSketch,
+    /// State sketch to retrieve the previous hash chain global index.
+    pub prev_hash_chain_global_index_sketch: EVMStateSketch,
+    /// State sketch to retrieve the new hash chain global index.
+    pub new_hash_chain_global_index_sketch: EVMStateSketch,
+    /// State sketch to retrieve the bridge address.
+    pub bridge_address_sketch: EVMStateSketch,
+    /// State sketch to retrieve the new LER.
     pub new_ler_sketch: EVMStateSketch,
 }
 
@@ -101,12 +112,86 @@ pub struct BridgeConstraintsInput {
 }
 
 impl BridgeConstraintsInput {
-    /// Verify the previous and new hash chain and its reconstruction.
-    fn verify_hash_chain(&self) -> Result<(), BridgeConstraintsError> {
+    /// Verify the previous and new hash chain global index and its
+    /// reconstruction.
+    #[allow(unused)]
+    fn verify_hash_chain_global_index(&self) -> Result<(), BridgeConstraintsError> {
         // 1.1 Get the state of the hash chain of the previous block on L2
         let prev_hash_chain: Digest = {
             let (decoded_return, retrieved_block_hash) = execute_static_call(
-                &self.bridge_witness.prev_hash_chain_sketch,
+                &self.bridge_witness.prev_hash_chain_global_index_sketch,
+                self.ger_addr,
+                // TODO: get previous hash chain global index
+                GlobalExitRootManagerL2SovereignChain::insertedGERHashChainCall {},
+            )
+            .map_err(|e| {
+                BridgeConstraintsError::static_call_error(e, StaticCallStage::PrevHashChain)
+            })?;
+
+            // check on block hash
+            if retrieved_block_hash != self.prev_l2_block_hash {
+                return Err(BridgeConstraintsError::MismatchBlockHash {
+                    retrieved: retrieved_block_hash,
+                    input: self.prev_l2_block_hash,
+                    // TODO: Bring context (GER or Claims)
+                    stage: StaticCallStage::PrevHashChain,
+                });
+            }
+
+            decoded_return.hashChain.0.into()
+        };
+
+        // 1.2 Get the state of the hash chain of the new block on L2
+        let new_hash_chain: Digest = {
+            let (decoded_return, retrieved_block_hash) = execute_static_call(
+                &self.bridge_witness.new_hash_chain_global_index_sketch,
+                self.ger_addr,
+                // TODO: get new hash chain global index
+                GlobalExitRootManagerL2SovereignChain::insertedGERHashChainCall {},
+            )
+            .map_err(|e| {
+                BridgeConstraintsError::static_call_error(e, StaticCallStage::NewHashChain)
+            })?;
+
+            // check on block hash
+            if retrieved_block_hash != self.new_l2_block_hash {
+                return Err(BridgeConstraintsError::MismatchBlockHash {
+                    retrieved: retrieved_block_hash,
+                    input: self.new_l2_block_hash,
+                    // TODO: Bring context (GER or Claims)
+                    stage: StaticCallStage::NewHashChain,
+                });
+            }
+
+            decoded_return.hashChain.0.into()
+        };
+
+        // 1.3 Check that the rebuilt hash chain is equal to the new hash chain
+        let rebuilt_hash_chain_global_index = self
+            .bridge_witness
+            .global_index_hashes
+            .iter()
+            .fold(prev_hash_chain, |acc, &global_index_hashed| {
+                keccak256_combine([acc, global_index_hashed])
+            });
+
+        if rebuilt_hash_chain_global_index != new_hash_chain {
+            // TODO: Bring context for hashchain mismatch (GER vs. Claims)
+            return Err(BridgeConstraintsError::MismatchHashChain {
+                computed: rebuilt_hash_chain_global_index,
+                input: new_hash_chain,
+            });
+        }
+
+        Ok(())
+    }
+
+    /// Verify the previous and new hash chain GER and its reconstruction.
+    fn verify_hash_chain_ger(&self) -> Result<(), BridgeConstraintsError> {
+        // 1.1 Get the state of the hash chain of the previous block on L2
+        let prev_hash_chain: Digest = {
+            let (decoded_return, retrieved_block_hash) = execute_static_call(
+                &self.bridge_witness.prev_hash_chain_ger_sketch,
                 self.ger_addr,
                 GlobalExitRootManagerL2SovereignChain::insertedGERHashChainCall {},
             )
@@ -129,7 +214,7 @@ impl BridgeConstraintsInput {
         // 1.2 Get the state of the hash chain of the new block on L2
         let new_hash_chain: Digest = {
             let (decoded_return, retrieved_block_hash) = execute_static_call(
-                &self.bridge_witness.new_hash_chain_sketch,
+                &self.bridge_witness.new_hash_chain_ger_sketch,
                 self.ger_addr,
                 GlobalExitRootManagerL2SovereignChain::insertedGERHashChainCall {},
             )
@@ -149,17 +234,18 @@ impl BridgeConstraintsInput {
             decoded_return.hashChain.0.into()
         };
 
-        // 1.3 Check that the reconstructed hash chain is equal to the new hash chain
-        let reconstructed_hash_chain = self
+        // 1.3 Check that the rebuilt hash chain is equal to the new hash chain
+        let rebuilt_hash_chain = self
             .bridge_witness
             .inserted_gers
             .iter()
             .map(|inserted_ger| inserted_ger.ger())
             .fold(prev_hash_chain, |acc, ger| keccak256_combine([acc, ger]));
 
-        if reconstructed_hash_chain != new_hash_chain {
+        if rebuilt_hash_chain != new_hash_chain {
+            // TODO: Bring context for hashchain mismatch (GER vs. Claims)
             return Err(BridgeConstraintsError::MismatchHashChain {
-                computed: reconstructed_hash_chain,
+                computed: rebuilt_hash_chain,
                 input: new_hash_chain,
             });
         }
@@ -176,7 +262,7 @@ impl BridgeConstraintsInput {
         let bridge_address = {
             // Execute the static call
             let (decoded_return, retrieved_block_hash) = execute_static_call(
-                &self.bridge_witness.get_bridge_address_sketch,
+                &self.bridge_witness.bridge_address_sketch,
                 self.ger_addr,
                 GlobalExitRootManagerL2SovereignChain::bridgeAddressCall {},
             )
@@ -252,7 +338,7 @@ impl BridgeConstraintsInput {
 
     /// Verify the bridge state.
     pub fn verify(&self) -> Result<(), BridgeConstraintsError> {
-        self.verify_hash_chain()?;
+        self.verify_hash_chain_ger()?;
         self.verify_new_ler()?;
         self.verify_inserted_gers()
     }
@@ -457,10 +543,13 @@ mod tests {
             },
             bridge_witness: BridgeWitness {
                 inserted_gers: imported_l1_info_tree_leafs,
-                prev_hash_chain_sketch: executor_prev_hash_chain_sketch.clone(),
-                new_hash_chain_sketch: executor_new_hash_chain.clone(),
-                get_bridge_address_sketch: executor_get_bridge_address_sketch,
+                prev_hash_chain_ger_sketch: executor_prev_hash_chain_sketch.clone(),
+                new_hash_chain_ger_sketch: executor_new_hash_chain.clone(),
+                bridge_address_sketch: executor_get_bridge_address_sketch,
                 new_ler_sketch: executor_get_ler_sketch,
+                global_index_hashes: todo!(),
+                prev_hash_chain_global_index_sketch: todo!(),
+                new_hash_chain_global_index_sketch: todo!(),
             },
         };
 

--- a/crates/aggchain-proof-core/src/error.rs
+++ b/crates/aggchain-proof-core/src/error.rs
@@ -1,4 +1,4 @@
-use crate::bridge::BridgeConstraintsError;
+use crate::{bridge::BridgeConstraintsError, Digest};
 
 /// Represents all the aggchain proof errors.
 #[derive(thiserror::Error, Debug)]
@@ -6,4 +6,26 @@ pub enum ProofError {
     /// Error on the bridge constraints.
     #[error(transparent)]
     BridgeConstraintsError(#[from] BridgeConstraintsError),
+    /// The L1 Head provided as public input of the FEP do not match the block
+    /// hash contained in the L1 info tree leaf used to verify the inclusion
+    /// proof to L1 info root.
+    #[error(
+        "Mismatch on the L1 head. from_l1_info_tree_leaf: {from_l1_info_tree_leaf}. \
+         from_fep_public_values: {from_fep_public_values}."
+    )]
+    MismatchL1Head {
+        from_l1_info_tree_leaf: Digest,
+        from_fep_public_values: Digest,
+    },
+    /// The inclusion proof of the L1 info tree leaf containing the L1 Head is
+    /// invalid.
+    #[error(
+        "Invalid inclusion proof for the L1 info tree leaf containing the L1 head. index: \
+         {index}, l1_leaf_hash: {l1_leaf_hash}, l1_info_root: {l1_info_root}."
+    )]
+    InvalidInclusionProofL1Head {
+        index: u32,
+        l1_leaf_hash: Digest,
+        l1_info_root: Digest,
+    },
 }

--- a/crates/aggchain-proof-core/src/lib.rs
+++ b/crates/aggchain-proof-core/src/lib.rs
@@ -5,4 +5,5 @@ mod keccak;
 mod local_exit_tree;
 pub mod proof;
 
+pub use bridge::inserted_ger::L1InfoTreeLeaf;
 pub use keccak::digest::Digest;

--- a/crates/aggchain-proof-core/src/proof.rs
+++ b/crates/aggchain-proof-core/src/proof.rs
@@ -4,7 +4,7 @@ use crate::{
     bridge::{BridgeConstraintsInput, BridgeWitness, L2_GER_ADDR},
     error::ProofError,
     full_execution_proof::FepWithPublicValues,
-    keccak::digest::Digest,
+    keccak::{digest::Digest, keccak256_combine},
 };
 
 /// Aggchain proof is generated from the FEP proof and additional
@@ -21,8 +21,6 @@ pub struct AggchainProofWitness {
     pub prev_local_exit_root: Digest,
     /// New local exit root.
     pub new_local_exit_root: Digest,
-    /// Commitment to the imported bridge exits indexes.
-    pub commit_imported_bridge_exits: Digest,
     /// L1 info root used to import bridge exits.
     pub l1_info_root: Digest,
     /// Origin network for which the proof was generated.
@@ -53,7 +51,9 @@ impl AggchainProofWitness {
             new_local_exit_root: self.new_local_exit_root,
             l1_info_root: self.l1_info_root,
             origin_network: self.origin_network,
-            commit_imported_bridge_exits: self.commit_imported_bridge_exits,
+            commit_imported_bridge_exits: keccak256_combine(
+                self.bridge_witness.global_index_hashes.iter(),
+            ),
             aggchain_params: self.fep.aggchain_params(),
         }
     }

--- a/crates/aggchain-proof-core/src/proof.rs
+++ b/crates/aggchain-proof-core/src/proof.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     bridge::{BridgeConstraintsInput, BridgeWitness, L2_GER_ADDR},
     error::ProofError,
-    full_execution_proof::FepWithPublicValues,
+    full_execution_proof::FepPublicValues,
     keccak::{digest::Digest, keccak256_combine},
 };
 
@@ -26,7 +26,7 @@ pub struct AggchainProofWitness {
     /// Origin network for which the proof was generated.
     pub origin_network: u32,
     /// Full execution proof with its metadata.
-    pub fep: FepWithPublicValues,
+    pub fep: FepPublicValues,
     /// Bridge witness related data.
     pub bridge_witness: BridgeWitness,
 }

--- a/crates/aggchain-proof-service/src/service.rs
+++ b/crates/aggchain-proof-service/src/service.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use aggchain_proof_builder::{AggchainProofBuilder, AggchainProofBuilderResponse};
-use aggchain_proof_core::proof::{InclusionProof, L1InfoTreeLeaf};
+use aggkit_prover_types::v1::{InclusionProof, L1InfoTreeLeaf};
 use aggkit_prover_types::Hash;
 use futures::{FutureExt as _, TryFutureExt};
 use proposer_service::{ProposerRequest, ProposerService};

--- a/crates/agglayer-prover-types/src/lib.rs
+++ b/crates/agglayer-prover-types/src/lib.rs
@@ -27,3 +27,4 @@ pub use error::Error;
 pub use error::ErrorWrapper;
 use serde::{Deserialize, Serialize};
 use sp1_sdk::SP1ProofWithPublicValues;
+


### PR DESCRIPTION
# Description

- [x] Add verification of the l1 head
- [x] Hardcode the hash of the aggregation vkey directly in the aggchain proof program
- [ ] Add constraints on the hash chain global index
  - [x] Compute the hash chain global index from the prover inputs
  - [ ] Put the right static calls to retrieve the new and prev hash chain global index
- [ ] Adapt for the `optimisticMode`
  - [ ] Align the `aggchain_params` expression
  - [ ] Add the case signature verification of the fep public values 

Fixes #76 

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
