### PR TITLE
ci: use stable toolchain for `doc` and `clippy`

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,12 +16,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
 
       - uses: taiki-e/install-action@protoc
 
       - name: Build Documentation
-        run: cargo +nightly doc --no-deps --all --all-features
+        run: cargo doc --no-deps --all --all-features
 
       - name: Add index file
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 

--- a/Makefile.ci.toml
+++ b/Makefile.ci.toml
@@ -23,6 +23,5 @@ dependencies = [{ name = "ci-clippy-workspace" }]
 
 [tasks.ci-clippy-workspace]
 category = "CI - CHECK"
-toolchain = "nightly"
 command = "cargo"
 args = ["clippy", "--workspace", "--tests", "--", "-D", "warnings"]


### PR DESCRIPTION
* see https://github.com/agglayer/agglayer/pull/708

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
