### PR TITLE
feat: make aggkit-prover startup faster by 2x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ dependencies = [
  "sp1-sdk",
  "thiserror 2.0.11",
  "tower 0.4.13",
+ "tracing",
 ]
 
 [[package]]
@@ -166,6 +167,7 @@ dependencies = [
  "http",
  "hyper-util",
  "prost",
+ "prover-config",
  "prover-engine",
  "prover-executor",
  "prover-logger",

--- a/crates/aggchain-proof-builder/Cargo.toml
+++ b/crates/aggchain-proof-builder/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true, features = ["derive"] }
 sp1-core-executor.workspace = true
 sp1-prover.workspace = true
 sp1-sdk.workspace = true
+tracing.workspace = true
 
 aggchain-proof-contracts.workspace = true
 aggchain-proof-core.workspace = true

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -110,16 +110,16 @@ impl<ContractsClient> AggchainProofBuilder<ContractsClient> {
         config: &AggchainProofBuilderConfig,
         contracts_client: Arc<ContractsClient>,
     ) -> Result<Self, Error> {
-        let executor = tower::ServiceBuilder::new()
-            .service(Executor::new(
-                &config.primary_prover,
-                &config.fallback_prover,
-                AGGCHAIN_PROOF_ELF,
-            ))
-            .boxed();
+        let executor = Executor::new(
+            &config.primary_prover,
+            &config.fallback_prover,
+            AGGCHAIN_PROOF_ELF,
+        );
+        let aggchain_proof_vkey = executor.get_vkey();
+
+        let executor = tower::ServiceBuilder::new().service(executor).boxed();
 
         let prover = Buffer::new(executor, MAX_CONCURRENT_REQUESTS);
-        let aggchain_proof_vkey = Executor::get_vkey(AGGCHAIN_PROOF_ELF);
 
         Ok(AggchainProofBuilder {
             contracts_client,

--- a/crates/aggkit-prover/Cargo.toml
+++ b/crates/aggkit-prover/Cargo.toml
@@ -30,6 +30,7 @@ aggchain-proof-types.workspace = true
 aggkit-prover-config.workspace = true
 aggkit-prover-types.workspace = true
 agglayer-interop = { workspace = true, features = ["grpc-compat"] }
+prover-config.workspace = true
 prover-engine.workspace = true
 prover-executor.workspace = true
 prover-logger.workspace = true

--- a/crates/aggkit-prover/src/main.rs
+++ b/crates/aggkit-prover/src/main.rs
@@ -1,6 +1,7 @@
 use aggkit_prover::version;
 use anyhow::Context as _;
 use clap::Parser as _;
+use prover_config::{CpuProverConfig, ProverType};
 use sp1_sdk::HashableKey as _;
 use sp1_zkvm::lib::utils::words_to_bytes_le;
 
@@ -31,8 +32,12 @@ fn main() -> anyhow::Result<()> {
             }
         }
         aggkit_prover::cli::Commands::Vkey => {
-            let vkey =
-                prover_executor::Executor::get_vkey(aggchain_proof_service::AGGCHAIN_PROOF_ELF);
+            let vkey = prover_executor::Executor::new(
+                &ProverType::CpuProver(CpuProverConfig::default()),
+                &None,
+                aggchain_proof_service::AGGCHAIN_PROOF_ELF,
+            )
+            .get_vkey();
             let vkey_hex = hex::encode(words_to_bytes_le(&vkey.hash_u32()));
 
             println!("aggchain_proof_vkey: 0x{vkey_hex}");

--- a/crates/agglayer-prover/src/lib.rs
+++ b/crates/agglayer-prover/src/lib.rs
@@ -1,7 +1,6 @@
 use std::{path::PathBuf, sync::Arc};
 
 use prover_engine::ProverEngine;
-use sp1_sdk::HashableKey;
 
 #[cfg(feature = "testutils")]
 pub mod fake;
@@ -50,11 +49,6 @@ pub fn main(cfg: PathBuf, version: &str, program: &'static [u8]) -> anyhow::Resu
         .start();
 
     Ok(())
-}
-
-pub fn get_vkey(program: &'static [u8]) -> String {
-    let vkey = prover_executor::Executor::get_vkey(program);
-    vkey.bytes32()
 }
 
 #[cfg(feature = "testutils")]

--- a/crates/proposer-service/src/lib.rs
+++ b/crates/proposer-service/src/lib.rs
@@ -62,7 +62,7 @@ impl<L1Rpc>
         let network_prover = new_network_prover(config.client.sp1_cluster_endpoint.as_str())
             .map_err(Error::UnableToCreateNetworkProver)?;
 
-        let aggregation_vkey = Self::extract_aggregation_vkey(AGGREGATION_ELF);
+        let aggregation_vkey = Self::extract_aggregation_vkey(&network_prover, AGGREGATION_ELF);
 
         Ok(Self {
             l1_rpc,
@@ -75,9 +75,8 @@ impl<L1Rpc>
         })
     }
 
-    fn extract_aggregation_vkey(elf: &[u8]) -> SP1VerifyingKey {
-        let client = sp1_sdk::ProverClient::builder().network().build();
-        let (_pkey, vkey) = client.setup(elf);
+    fn extract_aggregation_vkey(network_prover: &NetworkProver, elf: &[u8]) -> SP1VerifyingKey {
+        let (_pkey, vkey) = network_prover.setup(elf);
         vkey
     }
 }

--- a/crates/prover-executor/src/tests.rs
+++ b/crates/prover-executor/src/tests.rs
@@ -1,10 +1,10 @@
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use prover_config::MockProverConfig;
 use sp1_sdk::{
-    CpuProver, Prover, ProverClient, SP1ProofMode, SP1ProofWithPublicValues, SP1Stdin,
-    SP1_CIRCUIT_VERSION,
+    CpuProver, Prover, SP1ProofMode, SP1ProofWithPublicValues, SP1ProvingKey, SP1Stdin,
+    SP1VerifyingKey, SP1_CIRCUIT_VERSION,
 };
 use tower::timeout::TimeoutLayer;
 use tower::{service_fn, Service, ServiceBuilder, ServiceExt};
@@ -12,14 +12,30 @@ use tower::{service_fn, Service, ServiceBuilder, ServiceExt};
 use crate::{Executor, LocalExecutor, ProofType, Request, Response};
 const ELF: &[u8] = include_bytes!("../../prover-dummy-program/elf/riscv32im-succinct-zkvm-elf");
 
+fn cpu_prover() -> &'static CpuProver {
+    static RES: OnceLock<CpuProver> = OnceLock::new();
+    RES.get_or_init(|| CpuProver::new())
+}
+
+fn pkey_vkey() -> &'static (SP1ProvingKey, SP1VerifyingKey) {
+    static RES: OnceLock<(SP1ProvingKey, SP1VerifyingKey)> = OnceLock::new();
+    RES.get_or_init(|| cpu_prover().setup(ELF))
+}
+
+fn pkey() -> &'static SP1ProvingKey {
+    &pkey_vkey().0
+}
+
+fn vkey() -> &'static SP1VerifyingKey {
+    &pkey_vkey().1
+}
+
 fn mock_proof(stdin: SP1Stdin) -> SP1ProofWithPublicValues {
-    let client = ProverClient::builder().cpu().build();
-    let (pk, _vk) = client.setup(ELF);
-    let (public_values, _) = client.execute(&pk.elf, &stdin).run().unwrap();
+    let (public_values, _) = cpu_prover().execute(&pkey().elf, &stdin).run().unwrap();
 
     // Create a mock Plonk proof.
     SP1ProofWithPublicValues::create_mock_proof(
-        &pk,
+        pkey(),
         public_values,
         SP1ProofMode::Plonk,
         SP1_CIRCUIT_VERSION,
@@ -44,7 +60,7 @@ async fn executor_normal_behavior() {
         service_fn(|_: Request| async { panic!("Shouldn't be called") }),
     );
 
-    let mut executor = Executor::new_with_services(network, Some(local));
+    let mut executor = Executor::new_with_services(vkey().clone(), network, Some(local));
     let result = executor
         .call(Request {
             stdin: SP1Stdin::new(),
@@ -68,7 +84,7 @@ async fn executor_normal_behavior_only_network() {
         }),
     );
 
-    let mut executor = Executor::new_with_services(network, None);
+    let mut executor = Executor::new_with_services(vkey().clone(), network, None);
     let result = executor
         .call(Request {
             stdin: SP1Stdin::new(),
@@ -98,7 +114,7 @@ async fn executor_fallback_behavior_cpu() {
         }),
     );
 
-    let mut executor = Executor::new_with_services(network, Some(local));
+    let mut executor = Executor::new_with_services(vkey().clone(), network, Some(local));
     let result = executor
         .call(Request {
             stdin: SP1Stdin::new(),
@@ -134,7 +150,7 @@ async fn executor_fallback_because_of_timeout_cpu() {
         }),
     );
 
-    let mut executor = Executor::new_with_services(network, Some(local));
+    let mut executor = Executor::new_with_services(vkey().clone(), network, Some(local));
 
     let result = executor
         .call(Request {
@@ -174,7 +190,11 @@ async fn executor_fails_because_of_timeout_cpu() {
 
     let mut executor = ServiceBuilder::new()
         .layer(TimeoutLayer::new(Duration::from_millis(100)))
-        .service(Executor::new_with_services(network, Some(local)));
+        .service(Executor::new_with_services(
+            vkey().clone(),
+            network,
+            Some(local),
+        ));
 
     let result = executor
         .call(Request {
@@ -213,7 +233,11 @@ async fn executor_fails_because_of_concurrency_cpu() {
 
     let mut executor = ServiceBuilder::new()
         .layer(TimeoutLayer::new(Duration::from_secs(1)))
-        .service(Executor::new_with_services(network, Some(local)));
+        .service(Executor::new_with_services(
+            vkey().clone(),
+            network,
+            Some(local),
+        ));
 
     let mut executor2 = executor.clone();
 


### PR DESCRIPTION
Startup goes from ~14s to ~7s on my machine.

The time is heavily dominated by building the SP1 provers: each prover build takes ~3s. This PR removes two prover builds, and only leaves two: one for the aggregation elf, and one for the aggchain proof elf.

We might be able to shave another 3s (so another 2x factor) by only having a single prover, but it would be harder to implement, and is thus left as future work for now.

Fixes #126

## PR Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
