### PR TITLE
feat: add prover executor sp1 endpoint param

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5736,6 +5736,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "toml",
+ "url",
 ]
 
 [[package]]

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -20,6 +20,7 @@ network-id = 0
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]
 proving-timeout = "5m"
+sp1-cluster-endpoint = "https://rpc.production.succinct.xyz/"
 
 [aggchain-proof-service.aggchain-proof-builder.proving-timeout]
 secs = 3600
@@ -43,3 +44,4 @@ proving-timeout = 3600
 
 [primary-prover.network-prover]
 proving-timeout = "5m"
+sp1-cluster-endpoint = "https://rpc.production.succinct.xyz/"

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
@@ -23,6 +23,7 @@ network-id = 0
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]
 proving-timeout = "5m"
+sp1-cluster-endpoint = "https://rpc.production.succinct.xyz/"
 
 [aggchain-proof-service.aggchain-proof-builder.proving-timeout]
 secs = 3600
@@ -46,3 +47,4 @@ proving-timeout = 3600
 
 [primary-prover.network-prover]
 proving-timeout = "5m"
+sp1-cluster-endpoint = "https://rpc.production.succinct.xyz/"

--- a/crates/agglayer-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/agglayer-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -20,3 +20,4 @@ runtime-timeout = "5s"
 
 [primary-prover.network-prover]
 proving-timeout = "5m"
+sp1-cluster-endpoint = "https://rpc.production.succinct.xyz/"

--- a/crates/agglayer-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
+++ b/crates/agglayer-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
@@ -23,3 +23,4 @@ runtime-timeout = "5s"
 
 [primary-prover.network-prover]
 proving-timeout = "5m"
+sp1-cluster-endpoint = "https://rpc.production.succinct.xyz/"

--- a/crates/prover-config/Cargo.toml
+++ b/crates/prover-config/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 serde_with.workspace = true
+url.workspace = true
 
 prover-utils.workspace = true
 

--- a/crates/prover-config/src/lib.rs
+++ b/crates/prover-config/src/lib.rs
@@ -1,8 +1,13 @@
+use std::str::FromStr;
 use std::time::Duration;
 
-use prover_utils::with;
+use prover_utils::{from_env_or_default, with};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use url::Url;
+
+/// The default url endpoint for the grpc cluster service
+const DEFAULT_SP1_CLUSTER_ENDPOINT: &str = "https://rpc.production.succinct.xyz/";
 
 /// Type of the prover to be used for generation of the pessimistic proof
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone)]
@@ -65,6 +70,10 @@ pub struct NetworkProverConfig {
     #[serde(default = "default_network_proving_timeout")]
     #[serde(with = "crate::with::HumanDuration")]
     pub proving_timeout: Duration,
+
+    /// The sp1 proving cluster endpoint.
+    #[serde(default = "default_sp1_cluster_endpoint")]
+    pub sp1_cluster_endpoint: url::Url,
 }
 
 impl NetworkProverConfig {
@@ -82,6 +91,7 @@ impl Default for NetworkProverConfig {
         Self {
             proving_request_timeout: None,
             proving_timeout: default_network_proving_timeout(),
+            sp1_cluster_endpoint: default_sp1_cluster_endpoint(),
         }
     }
 }
@@ -166,4 +176,11 @@ const fn default_local_proving_timeout() -> Duration {
 
 const fn default_network_proving_timeout() -> Duration {
     Duration::from_secs(60 * 5)
+}
+
+fn default_sp1_cluster_endpoint() -> Url {
+    from_env_or_default(
+        "SP1_CLUSTER_ENDPOINT",
+        Url::from_str(DEFAULT_SP1_CLUSTER_ENDPOINT).unwrap(),
+    )
 }

--- a/crates/prover-config/tests/validate_deserialize.rs
+++ b/crates/prover-config/tests/validate_deserialize.rs
@@ -19,6 +19,7 @@ fn network_prover() {
         ProverType::NetworkProver(NetworkProverConfig {
             proving_request_timeout: Some(std::time::Duration::from_secs(300)),
             proving_timeout: std::time::Duration::from_secs(600),
+            sp1_cluster_endpoint: url::Url::parse("https://rpc.production.succinct.xyz/").unwrap(),
         })
     );
 }
@@ -48,6 +49,7 @@ fn network_and_cpu_prover() {
         ProverType::NetworkProver(NetworkProverConfig {
             proving_request_timeout: Some(std::time::Duration::from_secs(300)),
             proving_timeout: std::time::Duration::from_secs(600),
+            sp1_cluster_endpoint: url::Url::parse("https://rpc.production.succinct.xyz/").unwrap(),
         })
     );
 

--- a/crates/prover-executor/src/lib.rs
+++ b/crates/prover-executor/src/lib.rs
@@ -97,7 +97,10 @@ impl Executor {
         match prover_type {
             ProverType::NetworkProver(network_prover_config) => {
                 debug!("Creating network prover executor...");
-                let network_prover = ProverClient::builder().network().build();
+                let network_prover = ProverClient::builder()
+                    .network()
+                    .rpc_url(network_prover_config.sp1_cluster_endpoint.as_str())
+                    .build();
                 let (proving_key, verification_key) = network_prover.setup(program);
                 (
                     verification_key.clone(),


### PR DESCRIPTION
# Description

Added explicit `NetworkProverConfig` parameter for sp1 cluster endpoint.

Fixes https://github.com/agglayer/provers/issues/136