### PR TITLE
feat: separate `vkey` and `vkey-selector` subcommands

### DIFF
--- a/crates/aggkit-prover/src/cli/mod.rs
+++ b/crates/aggkit-prover/src/cli/mod.rs
@@ -29,5 +29,9 @@ pub enum Commands {
         config_path: PathBuf,
     },
 
+    /// Proof verification key.
     Vkey,
+
+    /// Proof verification key selector.
+    VkeySelector,
 }

--- a/crates/aggkit-prover/src/main.rs
+++ b/crates/aggkit-prover/src/main.rs
@@ -41,9 +41,12 @@ fn main() -> anyhow::Result<()> {
             let vkey = executor.get_vkey();
             let vkey_hex = hex::encode(words_to_bytes_le(&vkey.hash_u32()));
 
-            let vkey_selector_hex = hex::encode(AGGCHAIN_VKEY_SELECTOR.to_be_bytes());
+            println!("{vkey_hex}");
+        }
 
-            println!("aggchain_proof: 0x{vkey_selector_hex} => 0x{vkey_hex}");
+        aggkit_prover::cli::Commands::VkeySelector => {
+            let vkey_selector_hex = hex::encode(AGGCHAIN_VKEY_SELECTOR.to_be_bytes());
+            println!("{vkey_selector_hex}");
         }
     }
 


### PR DESCRIPTION
This brings the output format and subcommand names in line with `agglayer`. Also easier to parse in various integration scripts.

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
