### PR TITLE
fix: use the more recent error message for op-succinct

### DIFF
--- a/crates/proposer-client/src/mock_prover.rs
+++ b/crates/proposer-client/src/mock_prover.rs
@@ -62,7 +62,9 @@ impl AggregationProver for MockProver {
                 Ok(proof_response) => break proof_response,
                 Err(JsonRpcError::Call(error))
                     if error.code() == -32000
-                        && error.message().contains("proof request not complete") =>
+                        && error
+                            .message()
+                            .contains("agg proof request is still pending") =>
                 {
                     debug!(
                         request_id = real_request_id,


### PR DESCRIPTION
Part of https://github.com/agglayer/provers/issues/144

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
