### PR TITLE
fix: update vkey_hex encoding method to use hash_bytes

### DIFF
--- a/crates/aggkit-prover/src/main.rs
+++ b/crates/aggkit-prover/src/main.rs
@@ -4,7 +4,6 @@ use anyhow::Context as _;
 use clap::Parser as _;
 use prover_config::{CpuProverConfig, ProverType};
 use sp1_sdk::HashableKey as _;
-use sp1_zkvm::lib::utils::words_to_bytes_le;
 
 fn main() -> anyhow::Result<()> {
     dotenvy::dotenv().ok();
@@ -39,7 +38,7 @@ fn main() -> anyhow::Result<()> {
                 aggchain_proof_service::AGGCHAIN_PROOF_ELF,
             );
             let vkey = executor.get_vkey();
-            let vkey_hex = hex::encode(words_to_bytes_le(&vkey.hash_u32()));
+            let vkey_hex = hex::encode(vkey.hash_bytes());
 
             println!("{vkey_hex}");
         }


### PR DESCRIPTION
# Description

This PR is updating how we export the vkey of aggchain-proof

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
