### PR TITLE
feat: append 0x prefix to vkey and vkey selector

### DIFF
--- a/crates/aggkit-prover/src/main.rs
+++ b/crates/aggkit-prover/src/main.rs
@@ -38,14 +38,15 @@ fn main() -> anyhow::Result<()> {
                 aggchain_proof_service::AGGCHAIN_PROOF_ELF,
             );
             let vkey = executor.get_vkey();
-            let vkey_hex = hex::encode(vkey.hash_bytes());
+            let vkey_hex = hex::encode(vkey.hash_bytes()).trim_start_matches("0x");
 
-            println!("{vkey_hex}");
+            println!("0x{vkey_hex}");
         }
 
         aggkit_prover::cli::Commands::VkeySelector => {
-            let vkey_selector_hex = hex::encode(AGGCHAIN_VKEY_SELECTOR.to_be_bytes());
-            println!("{vkey_selector_hex}");
+            let vkey_selector_hex =
+                hex::encode(AGGCHAIN_VKEY_SELECTOR.to_be_bytes()).trim_start_matches("0x");
+            println!("0x{vkey_selector_hex}");
         }
     }
 

--- a/crates/aggkit-prover/src/main.rs
+++ b/crates/aggkit-prover/src/main.rs
@@ -38,15 +38,14 @@ fn main() -> anyhow::Result<()> {
                 aggchain_proof_service::AGGCHAIN_PROOF_ELF,
             );
             let vkey = executor.get_vkey();
-            let vkey_hex = hex::encode(vkey.hash_bytes()).trim_start_matches("0x");
-
-            println!("0x{vkey_hex}");
+            let vkey_hex = hex::encode(vkey.hash_bytes());
+            println!("0x{}", vkey_hex.trim_start_matches("0x"));
         }
 
         aggkit_prover::cli::Commands::VkeySelector => {
             let vkey_selector_hex =
-                hex::encode(AGGCHAIN_VKEY_SELECTOR.to_be_bytes()).trim_start_matches("0x");
-            println!("0x{vkey_selector_hex}");
+                hex::encode(AGGCHAIN_VKEY_SELECTOR.to_be_bytes());
+            println!("0x{}", vkey_selector_hex.trim_start_matches("0x"));
         }
     }
 

--- a/crates/aggkit-prover/src/main.rs
+++ b/crates/aggkit-prover/src/main.rs
@@ -43,8 +43,7 @@ fn main() -> anyhow::Result<()> {
         }
 
         aggkit_prover::cli::Commands::VkeySelector => {
-            let vkey_selector_hex =
-                hex::encode(AGGCHAIN_VKEY_SELECTOR.to_be_bytes());
+            let vkey_selector_hex = hex::encode(AGGCHAIN_VKEY_SELECTOR.to_be_bytes());
             println!("0x{}", vkey_selector_hex.trim_start_matches("0x"));
         }
     }


### PR DESCRIPTION
# Description

This PR standardizes the vkey and vkey-selector commands between agglayer and aggkit-prover.

Right now, `agglayer vkey` returns a hash with a `0x` prefix, but the others don't. To keep things consistent, this update adds the `0x` prefix to the aggkit-prover outputs too.

```bash
$ docker run --rm -it ghcr.io/agglayer/aggkit-prover:0.1.0-rc.20 bash
root@7eda38d77fff:/# aggkit-prover vkey
1f3df68a258f9d6748b291dd35faf80065af7cc11ef8b5fc6db2a4d958ea62d2
root@7eda38d77fff:/# aggkit-prover vkey-selector
00000001

$ docker run --rm -it ghcr.io/agglayer/agglayer:0.3.0-rc.16 bash
root@9ffb07528adf:/# agglayer vkey
0x00d6e4bdab9cac75a50d58262bb4e60b3107a6b61131ccdff649576c624b6fb7
root@9ffb07528adf:/# agglayer vkey-selector
00000001
```
