### PR TITLE
feat: update op succint public values

### DIFF
--- a/crates/aggchain-proof-core/src/full_execution_proof.rs
+++ b/crates/aggchain-proof-core/src/full_execution_proof.rs
@@ -53,6 +53,7 @@ sol! {
         uint64 l2BlockNumber;
         bytes32 rollupConfigHash;
         bytes32 multiBlockVKey;
+        address proverAddress;
     }
 }
 
@@ -65,6 +66,7 @@ impl From<&FepInputs> for AggregationProofPublicValues {
             l2BlockNumber: inputs.claim_block_num.into(),
             rollupConfigHash: inputs.rollup_config_hash.0.into(),
             multiBlockVKey: inputs.range_vkey_commitment.into(),
+            proverAddress: inputs.trusted_sequencer,
         }
     }
 }


### PR DESCRIPTION
# Description

Added [`trustedSequencer` as `proverAddress`](https://github.com/succinctlabs/op-succinct/blob/038c0bd9febc13e669f5946d48bea5e14c144b9c/contracts/src/validity/OPSuccinctL2OutputOracle.sol#L364) to ensure compatibility with the latest op-succinct version.

## Breaking changes

This will work with the latest version of op-succint, but won't work with the previous ones

## PR Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added or updated tests that comprehensively prove my change is effective or that my feature works
