### PR TITLE
chore: bump interop to v0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,7 @@ dependencies = [
 [[package]]
 name = "agglayer-evm-client"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/interop.git?tag=v0.5.0#6e51ba8ede65c8ffb8d341628cb94766fc5af298"
+source = "git+https://github.com/agglayer/interop.git?tag=v0.6.0#812bc77b4ac5f7159e9eaec525a05657e159d229"
 dependencies = [
  "agglayer-primitives",
  "alloy",
@@ -252,7 +252,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/interop.git?tag=v0.5.0#6e51ba8ede65c8ffb8d341628cb94766fc5af298"
+source = "git+https://github.com/agglayer/interop.git?tag=v0.6.0#812bc77b4ac5f7159e9eaec525a05657e159d229"
 dependencies = [
  "agglayer-interop-grpc-types",
  "agglayer-interop-types",
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop-grpc-types"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/interop.git?tag=v0.5.0#6e51ba8ede65c8ffb8d341628cb94766fc5af298"
+source = "git+https://github.com/agglayer/interop.git?tag=v0.6.0#812bc77b4ac5f7159e9eaec525a05657e159d229"
 dependencies = [
  "agglayer-interop-types",
  "bincode",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop-types"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/interop.git?tag=v0.5.0#6e51ba8ede65c8ffb8d341628cb94766fc5af298"
+source = "git+https://github.com/agglayer/interop.git?tag=v0.6.0#812bc77b4ac5f7159e9eaec525a05657e159d229"
 dependencies = [
  "agglayer-primitives",
  "agglayer-tries",
@@ -296,7 +296,7 @@ dependencies = [
 [[package]]
 name = "agglayer-primitives"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/interop.git?tag=v0.5.0#6e51ba8ede65c8ffb8d341628cb94766fc5af298"
+source = "git+https://github.com/agglayer/interop.git?tag=v0.6.0#812bc77b4ac5f7159e9eaec525a05657e159d229"
 dependencies = [
  "alloy-primitives",
  "byteorder",
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "agglayer-tries"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/interop.git?tag=v0.5.0#6e51ba8ede65c8ffb8d341628cb94766fc5af298"
+source = "git+https://github.com/agglayer/interop.git?tag=v0.6.0#812bc77b4ac5f7159e9eaec525a05657e159d229"
 dependencies = [
  "agglayer-primitives",
  "serde",
@@ -9237,7 +9237,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified-bridge"
 version = "0.1.0"
-source = "git+https://github.com/agglayer/interop.git?tag=v0.5.0#6e51ba8ede65c8ffb8d341628cb94766fc5af298"
+source = "git+https://github.com/agglayer/interop.git?tag=v0.6.0#812bc77b4ac5f7159e9eaec525a05657e159d229"
 dependencies = [
  "agglayer-primitives",
  "agglayer-tries",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,12 @@ prover-utils = { path = "crates/prover-utils" }
 agglayer-telemetry = { git = "https://github.com/agglayer/agglayer.git", branch = "release/0.2.1" }
 
 # Interop dependencies
-agglayer-evm-client = { git = "https://github.com/agglayer/interop.git", tag = "v0.5.0" }
-agglayer-interop = { git = "https://github.com/agglayer/interop.git", tag = "v0.5.0" }
-agglayer-interop-types = { git = "https://github.com/agglayer/interop.git", tag = "v0.5.0" }
-agglayer-primitives = { git = "https://github.com/agglayer/interop.git", tag = "v0.5.0" }
-agglayer-tries = { git = "https://github.com/agglayer/interop.git", tag = "v0.5.0" }
-unified-bridge = { git = "https://github.com/agglayer/interop.git", tag = "v0.5.0" }
+agglayer-evm-client = { git = "https://github.com/agglayer/interop.git", tag = "v0.6.0" }
+agglayer-interop = { git = "https://github.com/agglayer/interop.git", tag = "v0.6.0" }
+agglayer-interop-types = { git = "https://github.com/agglayer/interop.git", tag = "v0.6.0" }
+agglayer-primitives = { git = "https://github.com/agglayer/interop.git", tag = "v0.6.0" }
+agglayer-tries = { git = "https://github.com/agglayer/interop.git", tag = "v0.6.0" }
+unified-bridge = { git = "https://github.com/agglayer/interop.git", tag = "v0.6.0" }
 
 # Ecosystem dependencies
 op-succinct-elfs = { git = "https://github.com/agglayer/op-succinct.git", tag = "v2.1.3-agglayer" }

--- a/crates/aggchain-proof-program/Cargo.toml
+++ b/crates/aggchain-proof-program/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aggchain-proof-program"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2021"
 
 [profile.release]

--- a/crates/aggchain-proof-service/src/custom_chain_data/tests.rs
+++ b/crates/aggchain-proof-service/src/custom_chain_data/tests.rs
@@ -61,7 +61,7 @@ async fn test_custom_chain_data_builder_service() {
 
     let mut expected = [0u8; 96];
     // program selector
-    expected[0..4].copy_from_slice(&[0, 0, 0, 1]);
+    expected[0..4].copy_from_slice(&[0, 1, 0, 1]);
 
     // output root
     expected[32..64].copy_from_slice(&[1u8; 32]);


### PR DESCRIPTION
# Description

Bump `interop` version, increase aggchain proof program version