### PR TITLE
chore: re-add shutdown timeout for prover engine

### DIFF
--- a/crates/aggkit-prover/src/lib.rs
+++ b/crates/aggkit-prover/src/lib.rs
@@ -48,6 +48,7 @@ pub fn runtime(cfg: PathBuf, version: &str) -> anyhow::Result<()> {
         .set_cancellation_token(global_cancellation_token)
         .set_rpc_socket_addr(config.grpc_endpoint)
         .set_metric_socket_addr(config.telemetry.addr)
+        .set_shutdown_runtime_timeout(config.shutdown.runtime_timeout)
         .start();
 
     Ok(())

--- a/crates/agglayer-prover/src/lib.rs
+++ b/crates/agglayer-prover/src/lib.rs
@@ -46,6 +46,7 @@ pub fn main(cfg: PathBuf, version: &str, program: &'static [u8]) -> anyhow::Resu
         .set_cancellation_token(global_cancellation_token)
         .set_rpc_socket_addr(config.grpc_endpoint)
         .set_metric_socket_addr(config.telemetry.addr)
+        .set_shutdown_runtime_timeout(config.shutdown.runtime_timeout)
         .start();
 
     Ok(())


### PR DESCRIPTION
# Description

Shutdown timeout safeguard in case that the cancellation token haven't completed on time.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
