### PR TITLE
fix: comment `ProverEngine::start()` as sync-only

### DIFF
--- a/crates/aggkit-prover/src/lib.rs
+++ b/crates/aggkit-prover/src/lib.rs
@@ -40,6 +40,7 @@ pub fn runtime(cfg: PathBuf, version: &str) -> anyhow::Result<()> {
         )
     })?;
 
+    // NOTE: ProverEngine::start() is synchronous only and blocks the calling thread
     _ = ProverEngine::new(
         config.grpc_endpoint,
         config.telemetry.addr,

--- a/crates/agglayer-prover/src/lib.rs
+++ b/crates/agglayer-prover/src/lib.rs
@@ -39,6 +39,7 @@ pub fn main(cfg: PathBuf, version: &str, program: &'static [u8]) -> anyhow::Resu
     let pp_service =
         prover_runtime.block_on(async { crate::prover::Prover::create_service(&config, program) });
 
+    // NOTE: ProverEngine::start() is synchronous only and blocks the calling thread
     _ = ProverEngine::new(
         config.grpc_endpoint,
         config.telemetry.addr,

--- a/crates/prover-engine/src/lib.rs
+++ b/crates/prover-engine/src/lib.rs
@@ -13,6 +13,9 @@ use tracing::{debug, info};
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
+/// A prover engine that manages RPC and metrics servers.
+/// 
+/// NOTE: The `start()` method can only be called synchronously and will block the calling thread.
 pub struct ProverEngine {
     rpc_server: axum::Router,
     rpc_runtime: Option<Runtime>,
@@ -90,6 +93,9 @@ impl ProverEngine {
         self
     }
 
+    /// Starts the prover engine.
+    /// 
+    /// NOTE: This function can only be called synchronously and will block the calling thread.
     pub fn start(mut self) -> anyhow::Result<()> {
         info!("Starting the prover engine");
         let cancellation_token = self.cancellation_token.take().unwrap_or_default();


### PR DESCRIPTION
Signed-off-by: Dave Grantham <dgrantham@polygon.technology>

# Description

Fixes audit finding AGLO3.2-22.2. The fix per @Freyskeyd is to add comments marking the `ProverEngine::start()` function as synchronous-only that can block the async runtime.

Fixes [agglayer/security #114](https://github.com/agglayer/security/issues/114)

## Additions and Changes

### Bug fix (non-breaking change which fixes an issue)

Added comments to `ProverEngine::start()` as well as the callsites.

### New feature (non-breaking change which adds functionality)

None

## Breaking changes

None

## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
