### PR TITLE
feat: use U256 instead of global index

### DIFF
--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -275,7 +275,7 @@ impl<ContractsClient> AggchainProofBuilder<ContractsClient> {
             .iter()
             .filter(|ib| new_blocks_range.contains(&ib.block_number))
             .map(|ib| GlobalIndexWithLeafHash {
-                global_index: ib.global_index.into(),
+                global_index: ib.global_index,
                 bridge_exit_hash: ib.bridge_exit_hash.0,
             })
             .collect();

--- a/crates/aggchain-proof-types/src/imported_bridge_exit.rs
+++ b/crates/aggchain-proof-types/src/imported_bridge_exit.rs
@@ -1,4 +1,4 @@
-use agglayer_interop::types::GlobalIndex;
+use alloy_primitives::U256;
 use serde::{Deserialize, Serialize};
 
 // TODO: move this to interop repository
@@ -10,5 +10,5 @@ pub struct BridgeExitHash(pub agglayer_interop::types::Digest);
 pub struct ImportedBridgeExitWithBlockNumber {
     pub block_number: u64,
     pub bridge_exit_hash: BridgeExitHash,
-    pub global_index: GlobalIndex,
+    pub global_index: U256,
 }


### PR DESCRIPTION
# Description

Use `U256` directly instead of `GlobalIndex` in order to preserve the values of the padded unused bits.

Companion of:
- https://github.com/agglayer/interop/pull/44
- https://github.com/agglayer/agglayer/pull/857

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
