### PR TITLE
chore: make aggchain proof timeout config value human readable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "proposer-elfs",
  "prover-config",
  "prover-executor",
+ "prover-utils",
  "serde",
  "serde_json",
  "sp1-core-executor",

--- a/crates/aggchain-proof-builder/Cargo.toml
+++ b/crates/aggchain-proof-builder/Cargo.toml
@@ -26,6 +26,7 @@ agglayer-primitives.workspace = true
 aggkit-prover-types = { workspace = true, features = ["sp1"] }
 prover-config.workspace = true
 prover-executor.workspace = true
+prover-utils.workspace = true
 proposer-elfs.workspace = true
 serde_json.workspace = true
 unified-bridge.workspace = true

--- a/crates/aggchain-proof-builder/src/config.rs
+++ b/crates/aggchain-proof-builder/src/config.rs
@@ -19,6 +19,7 @@ pub struct AggchainProofBuilderConfig {
 
     /// Aggchain proof generation timeout in seconds.
     #[serde(default = "default_aggchain_prover_timeout")]
+    #[serde(with = "prover_utils::with::HumanDuration")]
     pub proving_timeout: Duration,
 
     /// Contract configuration

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__empty_rpcs.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/aggkit-prover-config/tests/validate_deserialize.rs
 expression: config
+snapshot_kind: text
 ---
 grpc-endpoint = "127.0.0.1:8081"
 
@@ -17,14 +18,11 @@ runtime-timeout = "30s"
 
 [aggchain-proof-service.aggchain-proof-builder]
 network-id = 0
+proving-timeout = "1h"
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]
 proving-timeout = "5m"
 sp1-cluster-endpoint = "https://rpc.production.succinct.xyz/"
-
-[aggchain-proof-service.aggchain-proof-builder.proving-timeout]
-secs = 3600
-nanos = 0
 
 [aggchain-proof-service.aggchain-proof-builder.contracts]
 l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"

--- a/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
+++ b/crates/aggkit-prover-config/tests/snapshots/validate_deserialize__prover_grpc_max_decoding_message_size.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/aggkit-prover-config/tests/validate_deserialize.rs
 expression: config
+snapshot_kind: text
 ---
 grpc-endpoint = "127.0.0.1:8081"
 
@@ -20,14 +21,11 @@ runtime-timeout = "30s"
 
 [aggchain-proof-service.aggchain-proof-builder]
 network-id = 0
+proving-timeout = "1h"
 
 [aggchain-proof-service.aggchain-proof-builder.primary-prover.network-prover]
 proving-timeout = "5m"
 sp1-cluster-endpoint = "https://rpc.production.succinct.xyz/"
-
-[aggchain-proof-service.aggchain-proof-builder.proving-timeout]
-secs = 3600
-nanos = 0
 
 [aggchain-proof-service.aggchain-proof-builder.contracts]
 l1-rpc-endpoint = "http://anvil-mock-l1-rpc:8545/"


### PR DESCRIPTION
* Fixes #215

CONFIG-CHANGE: The old aggchain proof timeout format with `secs` and `nanos` fields is no longer accepted. Use human format such as "1h" or "90s" instead. Key: `aggchain-proof-service.aggchain-proof-builder.proving-timeout`.

## PR Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added or updated tests that comprehensively prove my change is effective or that my feature works
