### PR TITLE
build: fixing ci semantic checks

### DIFF
--- a/.github/workflows/pr-checking.yml
+++ b/.github/workflows/pr-checking.yml
@@ -1,6 +1,7 @@
 name: Checking PR semantic
 
 on:
+  merge_group:
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
This PR is adding CI PR semantic checks to merge-group
