### PR TITLE
Fix typo in mock proof request log message

### DIFF
--- a/crates/proposer-client/src/rpc/mod.rs
+++ b/crates/proposer-client/src/rpc/mod.rs
@@ -141,7 +141,7 @@ impl AggregationProofProposer for ProposerRpcClient {
             .inspect_err(|e| error!("Get mock proof request failed: {e:?}"))
             .map_err(|e| Error::Requesting(Box::new(e)))?;
 
-        info!(proof_id = request.proof_id, "mock proof request fullfilled");
+        info!(proof_id = request.proof_id, "mock proof request fulfilled");
 
         Ok(response)
     }


### PR DESCRIPTION


## Description

Fixed a typo in the log message for mock proof requests:
- **Before:** `"mock proof request fullfilled"`
- **After:** `"mock proof request fulfilled"`

