### PR TITLE
feat: move all dynamic error types to eyre

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,8 +240,9 @@ dependencies = [
 
 [[package]]
 name = "agglayer-bincode"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16252ddbcf80d85c321dc3bab51b3b24f52fbc994902cd29e73df7ff09158ea4"
 dependencies = [
  "bincode",
  "serde",
@@ -249,8 +250,9 @@ dependencies = [
 
 [[package]]
 name = "agglayer-elf-build"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78e9b18dbaae513c3144b6bd0e2fa6b914ea41f39c193b615359126a26d9e563"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -260,8 +262,9 @@ dependencies = [
 
 [[package]]
 name = "agglayer-evm-client"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f27ccf78678b503d3d83626ad7155f283aa731d9b818b7265fd26a0d73096552"
 dependencies = [
  "agglayer-primitives",
  "alloy",
@@ -273,8 +276,9 @@ dependencies = [
 
 [[package]]
 name = "agglayer-interop"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95555251be0d99af326182d40a8ec3e74c642237ca5c6a89763ca1a217a3ef47"
 dependencies = [
  "agglayer-interop-grpc-types",
  "agglayer-interop-types",
@@ -282,8 +286,9 @@ dependencies = [
 
 [[package]]
 name = "agglayer-interop-grpc-types"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2570165ae31879b7eb03bf73d41635bb22ac3afc4abb08f88ecc7c777d59fce7"
 dependencies = [
  "agglayer-interop-types",
  "bincode",
@@ -296,8 +301,9 @@ dependencies = [
 
 [[package]]
 name = "agglayer-interop-types"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "777e0a8e38e7669c3fd81c3ce2ee0fb47c8e174ad1f7d04a222259eb59cda074"
 dependencies = [
  "agglayer-bincode",
  "agglayer-primitives",
@@ -315,8 +321,9 @@ dependencies = [
 
 [[package]]
 name = "agglayer-primitives"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8541aa678c7760cd445b8446ede22ecdd4fe78baada302a107231721b5e8385"
 dependencies = [
  "alloy-primitives 1.3.1",
  "byteorder",
@@ -401,8 +408,9 @@ dependencies = [
 
 [[package]]
 name = "agglayer-tries"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8ca2527b54038be55df6f05a7bb27a0c40d13dc120ea5956f21aae8c459874"
 dependencies = [
  "agglayer-primitives",
  "hex",
@@ -9980,8 +9988,9 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unified-bridge"
-version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88d192311bf505ee3abe2869210c7f9e98df01d62722a4e3309f53ac489bd7c"
 dependencies = [
  "agglayer-primitives",
  "agglayer-tries",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
 [[package]]
 name = "agglayer-bincode"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "bincode",
  "serde",
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "agglayer-elf-build"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "cargo_metadata",
  "clap",
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "agglayer-evm-client"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "agglayer-primitives",
  "alloy",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "agglayer-interop-grpc-types",
  "agglayer-interop-types",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop-grpc-types"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "agglayer-interop-types",
  "bincode",
@@ -297,7 +297,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop-types"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "agglayer-bincode",
  "agglayer-primitives",
@@ -316,7 +316,7 @@ dependencies = [
 [[package]]
 name = "agglayer-primitives"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "alloy-primitives 1.3.1",
  "byteorder",
@@ -402,7 +402,7 @@ dependencies = [
 [[package]]
 name = "agglayer-tries"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "agglayer-primitives",
  "hex",
@@ -9981,7 +9981,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified-bridge"
 version = "0.9.0"
-source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
+source = "git+https://github.com/agglayer/interop.git?rev=99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249#99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249"
 dependencies = [
  "agglayer-primitives",
  "agglayer-tries",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,8 +40,8 @@ dependencies = [
  "agglayer-interop",
  "agglayer-primitives",
  "alloy",
- "alloy-primitives 1.2.1",
- "anyhow",
+ "alloy-primitives 1.3.1",
+ "color-eyre",
  "eyre",
  "futures",
  "proposer-elfs",
@@ -69,7 +69,6 @@ dependencies = [
  "agglayer-interop",
  "agglayer-primitives",
  "alloy",
- "anyhow",
  "async-trait",
  "eyre",
  "jsonrpsee",
@@ -96,10 +95,11 @@ dependencies = [
  "agglayer-primitives",
  "agglayer-tries",
  "alloy",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-sol-macro",
  "alloy-sol-types",
+ "color-eyre",
  "dotenvy",
  "eyre",
  "hex",
@@ -135,9 +135,8 @@ dependencies = [
  "aggchain-proof-core",
  "aggchain-proof-types",
  "agglayer-interop",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-sol-types",
- "anyhow",
  "eyre",
  "futures",
  "proposer-client",
@@ -160,7 +159,7 @@ dependencies = [
  "aggchain-proof-core",
  "agglayer-interop",
  "agglayer-primitives",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "serde",
  "sp1-core-executor",
  "thiserror 2.0.12",
@@ -177,6 +176,7 @@ dependencies = [
  "agglayer-interop",
  "anyhow",
  "clap",
+ "color-eyre",
  "dotenvy",
  "eyre",
  "futures",
@@ -226,8 +226,8 @@ version = "0.1.0"
 dependencies = [
  "aggchain-proof-types",
  "agglayer-interop",
- "alloy-primitives 1.2.1",
- "anyhow",
+ "alloy-primitives 1.3.1",
+ "eyre",
  "pbjson",
  "prost",
  "prover-elf-utils",
@@ -241,8 +241,7 @@ dependencies = [
 [[package]]
 name = "agglayer-bincode"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b600f94a636bff0170bd11b2b93f4a7fd305be95bfbaa558e1a9a1f0e6a87bdd"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "bincode",
  "serde",
@@ -251,25 +250,23 @@ dependencies = [
 [[package]]
 name = "agglayer-elf-build"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bad143db162f9562c13b321d150a5b0c7633cb151d1b913e08f06a7bcf6038"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "anyhow",
  "cargo_metadata",
  "clap",
+ "eyre",
  "sp1-build",
 ]
 
 [[package]]
 name = "agglayer-evm-client"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3136c5a74d075bcba7837b71be64c6486a96ff7e47e92f6d67a631077a55ae1f"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "agglayer-primitives",
  "alloy",
- "anyhow",
  "async-trait",
+ "eyre",
  "mockall",
  "thiserror 2.0.12",
 ]
@@ -277,8 +274,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39edcae2dc53474844ff4b83385a0b8648c984319bb50d50b0700a9895503803"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "agglayer-interop-grpc-types",
  "agglayer-interop-types",
@@ -287,8 +283,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop-grpc-types"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99ea508c69dd2a77d58d4832d392d2128990cd3c6ec0addabab101c8b6f7f80"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "agglayer-interop-types",
  "bincode",
@@ -302,8 +297,7 @@ dependencies = [
 [[package]]
 name = "agglayer-interop-types"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3765e1cea355ce34e3e0dd824a5e57198bf3498ffe242be7758bf3a889b3f49"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "agglayer-bincode",
  "agglayer-primitives",
@@ -322,10 +316,9 @@ dependencies = [
 [[package]]
 name = "agglayer-primitives"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88e08a5ddabc0710ff57206a6222135e45b380d3f15f62ea5267c0a91bd42d9f"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "byteorder",
  "derive_more 2.0.1",
  "hex",
@@ -409,8 +402,7 @@ dependencies = [
 [[package]]
 name = "agglayer-tries"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2db770a5571e86a72e216d2711f519ba6887f63cfc57cb6c38c0ff0363b314d"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "agglayer-primitives",
  "hex",
@@ -477,7 +469,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6967ca1ed656766e471bc323da42fb0db320ca5e1418b408650e98e4757b3d2"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "num_enum 0.7.3",
  "serde",
@@ -491,7 +483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2179ba839ac532f50279f5da2a6c5047f791f03f6f808b4dfab11327b97902f"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-serde",
  "alloy-trie",
@@ -515,7 +507,7 @@ checksum = "aec6f67bdc62aa277e0ec13c1b1fb396c8a62b65c8e9bd8c1d3583cc6d1a8dd3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-serde",
  "serde",
@@ -532,7 +524,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-provider",
  "alloy-pubsub",
  "alloy-rpc-types-eth",
@@ -551,7 +543,7 @@ checksum = "a3c5a28f166629752f2e7246b813cdea3243cca59aab2d4264b1fd68392c10eb"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-sol-types",
 ]
@@ -563,7 +555,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18cc14d832bc3331ca22a1c7819de1ede99f58f61a7d123952af7dde8de124a6"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-sol-type-parser",
  "alloy-sol-types",
  "itoa",
@@ -578,7 +570,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "crc",
  "serde",
@@ -591,7 +583,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "serde",
 ]
@@ -602,7 +594,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "k256 0.13.4",
  "serde",
@@ -619,7 +611,7 @@ dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
@@ -639,7 +631,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-hardforks",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-sol-types",
  "auto_impl",
  "derive_more 2.0.1",
@@ -656,7 +648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dfec8348d97bd624901c6a4b22bb4c24df8a3128fc3d5e42d24f7b79dfa8588"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-serde",
  "alloy-trie",
  "serde",
@@ -670,7 +662,7 @@ checksum = "fbff8445282ec080c2673692062bd4930d7a0d6bda257caf138cfc650c503000"
 dependencies = [
  "alloy-chains",
  "alloy-eip2124",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "dyn-clone",
 ]
@@ -681,7 +673,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ccaa79753d7bf15f06399ea76922afbfaf8d18bebed9e8fc452984b4a90dcc9"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-sol-type-parser",
  "serde",
  "serde_json",
@@ -693,7 +685,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3994ab6ff6bdeb5aebe65381a8f6a47534789817570111555e8ac413e242ce06"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-sol-types",
  "serde",
  "serde_json",
@@ -712,7 +704,7 @@ dependencies = [
  "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -735,7 +727,7 @@ checksum = "498f2ee2eef38a6db0fc810c7bf7daebdf5f2fa8d04adb8bd53e54e91ddbdea3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-serde",
  "serde",
 ]
@@ -750,7 +742,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-op-hardforks",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "op-alloy-consensus",
  "op-revm",
@@ -791,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
+checksum = "bc9485c56de23438127a731a6b4c87803d49faf1a7068dcd1d8768aca3a9edb9"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -828,7 +820,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-pubsub",
  "alloy-rpc-client",
  "alloy-rpc-types-anvil",
@@ -869,7 +861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04135d2fd7fa1fba3afe9f79ec2967259dbc0948e02fa0cd0e33a4a812e2cb0a"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-transport",
  "bimap",
  "futures",
@@ -912,7 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6a6985b48a536b47aa0aece56e6a0f49240ce5d33a7f0c94f1b312eda79aa1"
 dependencies = [
  "alloy-json-rpc",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-pubsub",
  "alloy-transport",
  "alloy-transport-http",
@@ -939,7 +931,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf27873220877cb15125eb6eec2f86c6e9b41473aca85844bd3d9d755bfc0a0"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-engine",
  "alloy-rpc-types-eth",
@@ -955,7 +947,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c349f7339476f13e23308111dfeb67d136c11e7b2a6b1d162f6a124ad4ffb9b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -978,7 +970,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05525519bd7f37f98875354f0b3693d3ad3c7a7f067e3b8946777920be15cb5b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "serde",
 ]
 
@@ -990,7 +982,7 @@ checksum = "4235d79af20fe5583ca26096258fe9307571a345745c433cfd8c91b41aa2611e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.0.1",
@@ -1009,7 +1001,7 @@ dependencies = [
  "alloy-consensus-any",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
@@ -1025,7 +1017,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bccbe4594eaa2d69d21fa0b558c44e36202e599eb209da70b405415cb37a354"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -1039,7 +1031,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56b8de4afea88d9ca1504b9dee40ffae69a2364aed82ab6e88e4348b41f57f6b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "serde",
@@ -1051,7 +1043,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4dba6ff08916bc0a9cbba121ce21f67c0b554c39cf174bc7b9df6c651bd3c3b"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "serde",
  "serde_json",
 ]
@@ -1062,7 +1054,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c580da7f00f3999e44e327223044d6732358627f93043e22d92c583f6583556"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "async-trait",
  "auto_impl",
  "either",
@@ -1079,7 +1071,7 @@ checksum = "a00f0f07862bd8f6bc66c953660693c5903062c2c9d308485b2a6eee411089e7"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
@@ -1155,7 +1147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584cb97bfc5746cb9dcc4def77da11694b5d6d7339be91b7480a6a68dc129387"
 dependencies = [
  "alloy-json-abi",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-sol-macro",
  "serde",
 ]
@@ -1241,7 +1233,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "arrayvec",
  "derive_more 2.0.1",
@@ -1670,9 +1662,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2300,6 +2292,33 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -5137,7 +5156,7 @@ checksum = "1a09198717ebb22b201442c12a306a62de4a5d9535993b975c6bc0e5a919e2b1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-serde",
  "derive_more 2.0.1",
@@ -5155,7 +5174,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-network-primitives",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-eth",
  "alloy-serde",
  "derive_more 2.0.1",
@@ -5305,6 +5324,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "p256"
@@ -6085,7 +6110,7 @@ name = "proposer-client"
 version = "0.1.0"
 dependencies = [
  "agglayer-interop-types",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "anyhow",
  "async-trait",
  "base64 0.22.1",
@@ -6120,7 +6145,8 @@ name = "proposer-elfs"
 version = "0.1.0"
 dependencies = [
  "aggkit-prover-types",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
+ "color-eyre",
  "insta",
  "op-succinct-elfs",
  "prover-elf-utils",
@@ -6135,11 +6161,12 @@ dependencies = [
  "aggchain-proof-core",
  "aggkit-prover-types",
  "agglayer-evm-client",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-sol-types",
  "anyhow",
  "base64 0.22.1",
  "clap",
+ "color-eyre",
  "educe",
  "eyre",
  "futures",
@@ -6244,10 +6271,10 @@ version = "0.1.0"
 dependencies = [
  "agglayer-evm-client",
  "alloy",
- "anyhow",
  "async-trait",
  "derive_more 2.0.1",
  "educe",
+ "eyre",
  "ff 0.13.1",
  "mockall",
  "serde",
@@ -6706,7 +6733,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-trie",
  "auto_impl",
  "derive_more 2.0.1",
@@ -6724,7 +6751,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
@@ -6751,7 +6778,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "reth-execution-types",
  "reth-primitives-traits",
@@ -6776,7 +6803,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "bytes",
  "reth-primitives-traits",
  "serde",
@@ -6801,7 +6828,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "reth-chainspec",
  "reth-consensus",
  "reth-consensus-common",
@@ -6817,7 +6844,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-eip2124",
  "alloy-hardforks",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "once_cell",
  "rustc-hash 2.1.1",
@@ -6832,7 +6859,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-network",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "derive_more 2.0.1",
@@ -6854,7 +6881,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "auto_impl",
  "derive_more 2.0.1",
  "futures-util",
@@ -6877,7 +6904,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "reth-chainspec",
  "reth-ethereum-forks",
  "reth-ethereum-primitives",
@@ -6893,7 +6920,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "nybbles",
  "reth-storage-errors",
@@ -6908,7 +6935,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "derive_more 2.0.1",
  "reth-ethereum-primitives",
  "reth-primitives-traits",
@@ -6942,7 +6969,7 @@ name = "reth-network-peers"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "secp256k1",
  "serde_with",
@@ -6960,7 +6987,7 @@ dependencies = [
  "alloy-eips",
  "alloy-genesis",
  "alloy-hardforks",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "derive_more 2.0.1",
  "op-alloy-rpc-types",
  "reth-chainspec",
@@ -6979,7 +7006,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-trie",
  "op-alloy-consensus",
  "reth-chainspec",
@@ -7006,7 +7033,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-op-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "op-alloy-consensus",
  "op-revm",
  "reth-chainspec",
@@ -7028,7 +7055,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-op-hardforks",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "once_cell",
  "reth-ethereum-forks",
 ]
@@ -7041,7 +7068,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "bytes",
@@ -7078,7 +7105,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
@@ -7102,7 +7129,7 @@ name = "reth-prune-types"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "derive_more 2.0.1",
  "serde",
  "thiserror 2.0.12",
@@ -7113,7 +7140,7 @@ name = "reth-stages-types"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "bytes",
  "reth-trie-common",
  "serde",
@@ -7124,7 +7151,7 @@ name = "reth-static-file-types"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "derive_more 2.0.1",
  "serde",
  "strum 0.27.1",
@@ -7137,7 +7164,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types-engine",
  "auto_impl",
  "reth-chainspec",
@@ -7158,7 +7185,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "derive_more 2.0.1",
  "reth-primitives-traits",
@@ -7190,7 +7217,7 @@ source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac72
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-trie",
  "auto_impl",
@@ -7211,7 +7238,7 @@ version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
  "alloy-consensus",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -7232,7 +7259,7 @@ name = "reth-trie-sparse"
 version = "1.3.10"
 source = "git+https://github.com/paradigmxyz/reth?tag=v1.3.10#b36fc954d26258ac727b5cc13b771524411e1001"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "auto_impl",
  "metrics",
@@ -7419,7 +7446,7 @@ version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc2283ff87358ec7501956c5dd8724a6c2be959c619c4861395ae5e0054575f"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "enumn",
  "serde",
 ]
@@ -7524,7 +7551,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-evm",
  "alloy-network",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types",
  "itertools 0.13.0",
  "reth-chainspec",
@@ -7553,7 +7580,7 @@ name = "rsp-mpt"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?rev=881ba190e758e01e72399df462ac99864930ddb0#881ba190e758e01e72399df462ac99864930ddb0"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rlp",
  "alloy-rpc-types",
  "reth-trie",
@@ -7569,7 +7596,7 @@ source = "git+https://github.com/succinctlabs/rsp?rev=881ba190e758e01e72399df462
 dependencies = [
  "alloy-eips",
  "alloy-genesis",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types",
  "alloy-serde",
  "reth-chainspec",
@@ -7588,7 +7615,7 @@ name = "rsp-rpc-db"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?rev=881ba190e758e01e72399df462ac99864930ddb0#881ba190e758e01e72399df462ac99864930ddb0"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-provider",
  "alloy-rpc-types",
  "reth-storage-errors",
@@ -7605,7 +7632,7 @@ name = "rsp-witness-db"
 version = "0.1.0"
 source = "git+https://github.com/succinctlabs/rsp?rev=881ba190e758e01e72399df462ac99864930ddb0#881ba190e758e01e72399df462ac99864930ddb0"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "reth-storage-errors",
  "revm-database-interface",
  "revm-primitives",
@@ -8393,7 +8420,7 @@ dependencies = [
  "alloy-eips",
  "alloy-evm",
  "alloy-op-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
  "alloy-serde",
@@ -8431,7 +8458,7 @@ dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-evm",
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-sol-macro",
@@ -8821,7 +8848,7 @@ version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "463909ee4714c1409d8d169bafe7a61a10b4c727a3c715aff1c9b3e93c7d698a"
 dependencies = [
- "alloy-primitives 1.2.1",
+ "alloy-primitives 1.3.1",
  "anyhow",
  "async-trait",
  "backoff",
@@ -9722,6 +9749,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber 0.3.19",
+]
+
+[[package]]
 name = "tracing-forest"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9944,8 +9981,7 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 [[package]]
 name = "unified-bridge"
 version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ed7ffb6ee35350e44f40e4385ddda852802d43984a8ebfc238a8f0594c5ab24"
+source = "git+https://github.com/agglayer/interop.git?branch=ekleog%2Feyre-a-bit#baa9eb1e7c040e42f7eb80973c772a5bc9044396"
 dependencies = [
  "agglayer-primitives",
  "agglayer-tries",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,13 @@ prover-utils = { path = "crates/prover-utils" }
 agglayer-telemetry = { git = "https://github.com/agglayer/agglayer.git", branch = "release/0.2.1" }
 
 # Interop dependencies
-agglayer-elf-build = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
-agglayer-evm-client = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
-agglayer-interop = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
-agglayer-interop-types = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
-agglayer-primitives = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
-agglayer-tries = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
-unified-bridge = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
+agglayer-elf-build = "0.10.0"
+agglayer-evm-client = "0.10.0"
+agglayer-interop = "0.10.0"
+agglayer-interop-types = "0.10.0"
+agglayer-primitives = "0.10.0"
+agglayer-tries = "0.10.0"
+unified-bridge = "0.10.0"
 
 # Ecosystem dependencies
 op-succinct-elfs = { git = "https://github.com/agglayer/op-succinct.git", tag = "v2.3.1-agglayer" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,13 @@ prover-utils = { path = "crates/prover-utils" }
 agglayer-telemetry = { git = "https://github.com/agglayer/agglayer.git", branch = "release/0.2.1" }
 
 # Interop dependencies
-agglayer-elf-build = "0.9.0"
-agglayer-evm-client = "0.9.0"
-agglayer-interop = "0.9.0"
-agglayer-interop-types = "0.9.0"
-agglayer-primitives = "0.9.0"
-agglayer-tries = "0.9.0"
-unified-bridge = "0.9.0"
+agglayer-elf-build = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-evm-client = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-interop = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-interop-types = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-primitives = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-tries = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+unified-bridge = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
 
 # Ecosystem dependencies
 op-succinct-elfs = { git = "https://github.com/agglayer/op-succinct.git", tag = "v2.3.1-agglayer" }
@@ -87,6 +87,7 @@ async-trait = "0.1.82"
 base64 = "0.22.0"
 buildstructor = "0.5.4"
 clap = { version = "4.5", features = ["derive", "env"] }
+color-eyre = "0.6.5"
 derive_more = "2.0"
 dirs = "5.0"
 dotenvy = "0.15.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,13 @@ prover-utils = { path = "crates/prover-utils" }
 agglayer-telemetry = { git = "https://github.com/agglayer/agglayer.git", branch = "release/0.2.1" }
 
 # Interop dependencies
-agglayer-elf-build = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
-agglayer-evm-client = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
-agglayer-interop = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
-agglayer-interop-types = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
-agglayer-primitives = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
-agglayer-tries = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
-unified-bridge = { git = "https://github.com/agglayer/interop.git", branch = "ekleog/eyre-a-bit" }
+agglayer-elf-build = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
+agglayer-evm-client = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
+agglayer-interop = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
+agglayer-interop-types = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
+agglayer-primitives = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
+agglayer-tries = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
+unified-bridge = { git = "https://github.com/agglayer/interop.git", rev = "99f2f2d12f839c77e67b3b3a3c4f94bd8ab82249" }
 
 # Ecosystem dependencies
 op-succinct-elfs = { git = "https://github.com/agglayer/op-succinct.git", tag = "v2.3.1-agglayer" }

--- a/crates/aggchain-proof-builder/Cargo.toml
+++ b/crates/aggchain-proof-builder/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 alloy.workspace = true
 alloy-primitives.workspace = true
 
@@ -37,6 +36,9 @@ unified-bridge.workspace = true
 tokio.workspace = true
 
 [build-dependencies]
+color-eyre.workspace = true
+eyre.workspace = true
+
 agglayer-elf-build.workspace = true
 
 [lints]

--- a/crates/aggchain-proof-builder/build.rs
+++ b/crates/aggchain-proof-builder/build.rs
@@ -1,5 +1,6 @@
-pub fn main() -> agglayer_elf_build::Result<()> {
-    agglayer_elf_build::build_program("crates/aggchain-proof-program").map(|elf_path| {
-        eprintln!("ELF_PATH={elf_path}");
-    })
+pub fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
+    let elf_path = agglayer_elf_build::build_program("crates/aggchain-proof-program")?;
+    eprintln!("ELF_PATH={elf_path}");
+    Ok(())
 }

--- a/crates/aggchain-proof-builder/src/error.rs
+++ b/crates/aggchain-proof-builder/src/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
     ProverServiceError(String),
 
     #[error("Prover failed to prove the transaction")]
-    ProverFailedToExecute(#[source] anyhow::Error),
+    ProverFailedToExecute(#[source] tower::BoxError),
 
     #[error("Generated proof is not Compressed one (STARK)")]
     GeneratedProofIsNotCompressed,

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -443,7 +443,7 @@ where
                     proof_type: ProofType::Stark,
                 })
                 .await
-                .map_err(|error| Error::ProverFailedToExecute(anyhow::Error::from_boxed(error)))?;
+                .map_err(Error::ProverFailedToExecute)?;
 
             let public_input: AggchainProofPublicValues = bincode::sp1v4()
                 .deserialize(proof.public_values.as_slice())

--- a/crates/aggchain-proof-builder/src/tests/mod.rs
+++ b/crates/aggchain-proof-builder/src/tests/mod.rs
@@ -5,7 +5,7 @@ pub fn dump_aggchain_prover_inputs_json(
     aggchain_prover_inputs: &AggchainProverInputs,
     last_proven_block: u64,
     end_block: u64,
-) -> Result<(), anyhow::Error> {
+) -> eyre::Result<()> {
     use std::io::Write;
     let file_name =
         format!("aggchain_prover_inputs_001_lpb_{last_proven_block}_eb_{end_block}.json",);
@@ -68,7 +68,7 @@ mod aggchain_proof_builder {
                 proof_type: prover_executor::ProofType::Stark,
             })
             .await
-            .map_err(|error| Error::ProverFailedToExecute(anyhow::Error::from_boxed(error)))?;
+            .map_err(Error::ProverFailedToExecute)?;
 
         println!("Prover executor successfully returned response: {proof:?}");
 

--- a/crates/aggchain-proof-contracts/Cargo.toml
+++ b/crates/aggchain-proof-contracts/Cargo.toml
@@ -6,7 +6,6 @@ license.workspace = true
 
 [dependencies]
 alloy = { workspace = true, features = ["genesis"] }
-anyhow.workspace = true
 async-trait.workspace = true
 eyre.workspace = true
 jsonrpsee.workspace = true

--- a/crates/aggchain-proof-contracts/src/error.rs
+++ b/crates/aggchain-proof-contracts/src/error.rs
@@ -4,7 +4,7 @@ use sp1_cc_host_executor::HostError;
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Unable to create alloy node provider")]
-    ProviderInitializationError(#[source] anyhow::Error),
+    ProviderInitializationError(#[source] eyre::Error),
 
     #[error("Error processing contract ABI file")]
     ContractAbiFileError(#[source] std::io::Error),

--- a/crates/aggchain-proof-core/Cargo.toml
+++ b/crates/aggchain-proof-core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
+color-eyre.workspace = true
 semver.workspace = true
 toml.workspace = true
 

--- a/crates/aggchain-proof-core/build.rs
+++ b/crates/aggchain-proof-core/build.rs
@@ -4,6 +4,8 @@ use semver::Version;
 use toml::Value;
 
 fn main() {
+    color_eyre::install().unwrap();
+
     println!("cargo:rerun-if-changed=Cargo.toml");
     let cargo_toml_path = Path::new("../aggchain-proof-program/Cargo.toml");
     println!("cargo:rerun-if-changed={}", cargo_toml_path.display());

--- a/crates/aggchain-proof-core/src/proof.rs
+++ b/crates/aggchain-proof-core/src/proof.rs
@@ -1,6 +1,6 @@
 use agglayer_primitives::Digest;
 use serde::{Deserialize, Serialize};
-use unified_bridge::{AggchainProofPublicValues, CommitmentVersion};
+use unified_bridge::{AggchainProofPublicValues, ImportedBridgeExitCommitmentVersion};
 
 use crate::{
     bridge::{BridgeConstraintsInput, BridgeWitness, L2_GER_ADDR},
@@ -9,7 +9,8 @@ use crate::{
 };
 
 /// Version of the commitment on the imported bridge exits.
-pub const IMPORTED_BRIDGE_EXIT_COMMITMENT_VERSION: CommitmentVersion = CommitmentVersion::V3;
+pub const IMPORTED_BRIDGE_EXIT_COMMITMENT_VERSION: ImportedBridgeExitCommitmentVersion =
+    ImportedBridgeExitCommitmentVersion::V3;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct AggchainProofWitness {

--- a/crates/aggchain-proof-service/Cargo.toml
+++ b/crates/aggchain-proof-service/Cargo.toml
@@ -21,7 +21,6 @@ unified-bridge.workspace = true
 
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
-anyhow.workspace = true
 futures.workspace = true
 serde.workspace = true
 sp1-sdk = { workspace = true }

--- a/crates/aggchain-proof-service/src/error.rs
+++ b/crates/aggchain-proof-service/src/error.rs
@@ -1,7 +1,7 @@
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
     #[error("Unable to create alloy provider")]
-    AlloyProviderInitializationFailed(#[source] anyhow::Error),
+    AlloyProviderInitializationFailed(#[source] eyre::Error),
 
     #[error("Unable to setup proposer service")]
     ProposerServiceInitFailed(#[source] proposer_service::Error),

--- a/crates/aggkit-prover-types/Cargo.toml
+++ b/crates/aggkit-prover-types/Cargo.toml
@@ -9,7 +9,7 @@ sp1 = ["dep:sp1-sdk", "dep:prover-elf-utils"]
 
 [dependencies]
 alloy-primitives.workspace = true
-anyhow.workspace = true
+eyre.workspace = true
 prost.workspace = true
 serde.workspace = true
 thiserror.workspace = true

--- a/crates/aggkit-prover-types/src/conversion/v1/aggchain_proof_inputs.rs
+++ b/crates/aggkit-prover-types/src/conversion/v1/aggchain_proof_inputs.rs
@@ -17,7 +17,7 @@ impl TryFrom<v1::GenerateAggchainProofRequest> for AggchainProofInputs {
                 .try_into()
                 .map_err(|error| Error::InvalidDigest {
                     field_path: "l1_info_tree_root_hash".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
             l1_info_tree_leaf: value
                 .l1_info_tree_leaf
@@ -27,7 +27,7 @@ impl TryFrom<v1::GenerateAggchainProofRequest> for AggchainProofInputs {
                 .try_into()
                 .map_err(|error| Error::InvalidL1InfoTreeLeaf {
                     field_path: "l1_info_tree_leaf".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
             l1_info_tree_merkle_proof: value
                 .l1_info_tree_merkle_proof
@@ -37,7 +37,7 @@ impl TryFrom<v1::GenerateAggchainProofRequest> for AggchainProofInputs {
                 .try_into()
                 .map_err(|source| Error::InvalidL1InfoTreeMerkleProof {
                     field_path: "l1_info_tree_merkle_proof".to_string(),
-                    source: anyhow::Error::from(source),
+                    source: eyre::Error::from(source),
                 })?,
             ger_leaves: value
                 .ger_leaves
@@ -48,7 +48,7 @@ impl TryFrom<v1::GenerateAggchainProofRequest> for AggchainProofInputs {
                         v.try_into().map_err(|error| {
                             Error::InvalidInsertedGerWithBlockNumberConversion {
                                 field_path: "ger_leaves".to_string(),
-                                source: anyhow::Error::from(error),
+                                source: eyre::Error::from(error),
                             }
                         })?,
                     ))
@@ -61,7 +61,7 @@ impl TryFrom<v1::GenerateAggchainProofRequest> for AggchainProofInputs {
                 .collect::<Result<_, _>>()
                 .map_err(|error| Error::InvalidImportedBridgeExit {
                     field_path: "imported_bridge_exits".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
         })
     }

--- a/crates/aggkit-prover-types/src/conversion/v1/imported_bridge_exit.rs
+++ b/crates/aggkit-prover-types/src/conversion/v1/imported_bridge_exit.rs
@@ -18,7 +18,7 @@ impl TryFrom<v1::ImportedBridgeExitWithBlockNumber> for ImportedBridgeExitWithBl
                 .try_into()
                 .map_err(|error| Error::InvalidDigest {
                     field_path: "global_index".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
             bridge_exit_hash: BridgeExitHash(
                 value
@@ -29,7 +29,7 @@ impl TryFrom<v1::ImportedBridgeExitWithBlockNumber> for ImportedBridgeExitWithBl
                     .try_into()
                     .map_err(|error| Error::InvalidDigest {
                         field_path: "global_index".to_string(),
-                        source: anyhow::Error::from(error),
+                        source: eyre::Error::from(error),
                     })?,
             ),
         })

--- a/crates/aggkit-prover-types/src/conversion/v1/inserted_ger.rs
+++ b/crates/aggkit-prover-types/src/conversion/v1/inserted_ger.rs
@@ -17,7 +17,7 @@ impl TryFrom<v1::ProvenInsertedGerWithBlockNumber> for InsertedGerWithBlockNumbe
                 .try_into()
                 .map_err(|error| Error::InvalidInsertedGer {
                     field_path: "proven_inserted_ger".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
         })
     }
@@ -36,7 +36,7 @@ impl TryFrom<v1::ProvenInsertedGer> for InsertedGer {
                 .try_into()
                 .map_err(|error| Error::InvalidInsertedGer {
                     field_path: "proof_ger_l1root".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
             l1_leaf: value
                 .l1_leaf
@@ -46,7 +46,7 @@ impl TryFrom<v1::ProvenInsertedGer> for InsertedGer {
                 .try_into()
                 .map_err(|error| Error::InvalidL1InfoTreeLeaf {
                     field_path: "l1_leaf".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
         })
     }

--- a/crates/aggkit-prover-types/src/conversion/v1/optimistic_aggchain_proof_types.rs
+++ b/crates/aggkit-prover-types/src/conversion/v1/optimistic_aggchain_proof_types.rs
@@ -17,7 +17,7 @@ impl TryFrom<v1::GenerateOptimisticAggchainProofRequest> for OptimisticAggchainP
                 .try_into()
                 .map_err(|error| Error::InvalidOptimisticModeSignature {
                     field_path: "optimistic_mode_signature".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
             aggchain_proof_inputs: value
                 .aggchain_proof_request
@@ -27,7 +27,7 @@ impl TryFrom<v1::GenerateOptimisticAggchainProofRequest> for OptimisticAggchainP
                 .try_into()
                 .map_err(|error| Error::InvalidAggchainProofRequest {
                     field_path: "aggchain_proof_request".to_string(),
-                    source: anyhow::Error::from(error),
+                    source: eyre::Error::from(error),
                 })?,
         })
     }

--- a/crates/aggkit-prover-types/src/error.rs
+++ b/crates/aggkit-prover-types/src/error.rs
@@ -20,7 +20,7 @@ pub enum AggchainProofRequestError {
     #[error("Invalid l1 info tree leaf")]
     InvalidL1InfoTreeLeaf {
         field_path: String,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
 
     #[error("Missing l1 info tree root hash")]
@@ -31,14 +31,14 @@ pub enum AggchainProofRequestError {
 
     #[error("Invalid l1 info tree merkle proof")]
     InvalidL1InfoTreeMerkleProof {
-        source: anyhow::Error,
+        source: eyre::Error,
         field_path: String,
     },
 
     #[error("Invalid inserted GER with block number conversion")]
     InvalidInsertedGerWithBlockNumberConversion {
         field_path: String,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
 
     #[error("Missing inclusion proof")]
@@ -47,13 +47,13 @@ pub enum AggchainProofRequestError {
     #[error("Invalid digest")]
     InvalidDigest {
         field_path: String,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
 
     #[error("Invalid imported bridge exit")]
     InvalidImportedBridgeExit {
         field_path: String,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
 
     #[error("Missing imported bridge exit")]
@@ -63,12 +63,12 @@ pub enum AggchainProofRequestError {
     #[error("Invalid inserted ger")]
     InvalidInsertedGer {
         field_path: String,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
     #[error("Invalid optimistic mode signature")]
     InvalidOptimisticModeSignature {
         field_path: String,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
     #[error("Missing optimistic mode signature")]
     MissingOptimisticModeSignature { field_path: String },
@@ -76,7 +76,7 @@ pub enum AggchainProofRequestError {
     #[error("Invalid aggchain-proof request")]
     InvalidAggchainProofRequest {
         field_path: String,
-        source: anyhow::Error,
+        source: eyre::Error,
     },
     #[error("Missing aggchain-proof request")]
     MissingAggchainProofRequest { field_path: String },

--- a/crates/aggkit-prover/Cargo.toml
+++ b/crates/aggkit-prover/Cargo.toml
@@ -45,6 +45,8 @@ mockall.workspace = true
 tokio-stream = { workspace = true, features = ["sync"] }
 
 [build-dependencies]
+color-eyre.workspace = true
+eyre.workspace = true
 vergen-git2 = { version = "1.0.0", features = ["build"] }
 
 [features]

--- a/crates/aggkit-prover/build.rs
+++ b/crates/aggkit-prover/build.rs
@@ -1,13 +1,17 @@
+use eyre::eyre;
 use vergen_git2::{Emitter, Git2Builder};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
     Emitter::new()
         .add_instructions(
             &Git2Builder::default()
                 .describe(true, true, None)
                 .commit_timestamp(true)
                 .build()?,
-        )?
-        .emit()?;
+        )
+        .map_err(|e| eyre!(e))?
+        .emit()
+        .map_err(|e| eyre!(e))?;
     Ok(())
 }

--- a/crates/proposer-client/src/error.rs
+++ b/crates/proposer-client/src/error.rs
@@ -34,5 +34,5 @@ pub enum ProofRequestError {
 #[error("Conversion of `{field}` failed")]
 pub struct GrpcConversionError {
     pub field: &'static str,
-    pub source: anyhow::Error,
+    pub source: eyre::Error,
 }

--- a/crates/proposer-client/src/rpc/proofs_service_types.rs
+++ b/crates/proposer-client/src/rpc/proofs_service_types.rs
@@ -4,7 +4,7 @@ use super::{
     MockProofProposerRequest, MockProofProposerResponse,
 };
 
-fn convert_field<T, U: TryFrom<T, Error = E>, E: Into<anyhow::Error>>(
+fn convert_field<T, U: TryFrom<T, Error = E>, E: Into<eyre::Error>>(
     field: &'static str,
     value: T,
 ) -> Result<U, GrpcConversionError> {

--- a/crates/proposer-client/src/tests/proposer_rpc.rs
+++ b/crates/proposer-client/src/tests/proposer_rpc.rs
@@ -24,7 +24,7 @@ fn create_agg_proof_request() -> AggregationProofProposerRequest {
 async fn create_mock_grpc_proposer<F>(
     request: AggProofRequest,
     response_handler: F,
-) -> anyhow::Result<mock_server::Handle>
+) -> eyre::Result<mock_server::Handle>
 where
     F: Fn(
             tonic::Request<AggProofRequest>,

--- a/crates/proposer-elfs/Cargo.toml
+++ b/crates/proposer-elfs/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [build-dependencies]
+color-eyre.workspace = true
 op-succinct-elfs.workspace = true
 prover-elf-utils.workspace = true
 

--- a/crates/proposer-elfs/build.rs
+++ b/crates/proposer-elfs/build.rs
@@ -1,4 +1,5 @@
 fn main() {
+    color_eyre::install().unwrap();
     prover_elf_utils::ElfInfo::writing_to("vkeys_raw.rs")
         // Verification keys for aggregation proof
         .module("aggregation", op_succinct_elfs::AGGREGATION_ELF)

--- a/crates/proposer-service/Cargo.toml
+++ b/crates/proposer-service/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 aggchain-proof-core.workspace = true
 aggkit-prover-types = { workspace = true, features = ["sp1"] }
 agglayer-evm-client.workspace = true
+color-eyre.workspace = true
 eyre.workspace = true
 proposer-client.workspace = true
 prover-alloy.workspace = true

--- a/crates/proposer-service/src/error.rs
+++ b/crates/proposer-service/src/error.rs
@@ -3,7 +3,7 @@ use proposer_client::error::Error as ProposerClientError;
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error(transparent)]
-    AlloyProviderError(anyhow::Error),
+    AlloyProviderError(eyre::Error),
 
     #[error("Proposer client error: {0}")]
     Client(#[from] ProposerClientError),

--- a/crates/proposer-service/src/lib.rs
+++ b/crates/proposer-service/src/lib.rs
@@ -145,7 +145,7 @@ impl<L1Rpc>
 impl<L1Rpc, ProposerClient> tower::Service<FepProposerRequest>
     for ProposerService<L1Rpc, ProposerClient>
 where
-    L1Rpc: GetBlockNumber<Error: Into<anyhow::Error>> + Send + Sync + 'static,
+    L1Rpc: GetBlockNumber<Error: Into<eyre::Error>> + Send + Sync + 'static,
     ProposerClient: proposer_client::ProposerClient + Send + Sync + 'static,
 {
     type Response = ProposerResponse;
@@ -178,7 +178,7 @@ where
                 .map_err(|e| {
                     Error::AlloyProviderError(
                         e.into()
-                            .context(format!("Getting the block number for hash {l1_block_hash}")),
+                            .wrap_err(format!("Getting the block number for hash {l1_block_hash}")),
                     )
                 })?;
 

--- a/crates/proposer-service/src/tests/mod.rs
+++ b/crates/proposer-service/src/tests/mod.rs
@@ -108,7 +108,7 @@ async fn unable_to_fetch_block_hash() {
     l1_rpc
         .expect_get_block_number()
         .once()
-        .returning(|_| anyhow::bail!("Failed to fetch block number"));
+        .returning(|_| eyre::bail!("Failed to fetch block number"));
 
     let client = MockProposerClient::new();
 

--- a/crates/proposer-service/src/tests/proposer_service_test_program.rs
+++ b/crates/proposer-service/src/tests/proposer_service_test_program.rs
@@ -1,7 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
 use alloy_primitives::B256;
-use anyhow::anyhow;
 use clap::Parser;
 use proposer_client::{config::ProposerClientConfig, FepProposerRequest, GrpcUri};
 use proposer_service::{config::ProposerServiceConfig, ProposerService};
@@ -45,8 +44,9 @@ struct Cli {
 }
 
 #[tokio::main]
-pub async fn main() -> anyhow::Result<()> {
+pub async fn main() -> eyre::Result<()> {
     println!("Starting Proposer service test...");
+    color_eyre::install()?;
 
     // Initialize the tracing
     prover_logger::tracing(&Log::default());
@@ -98,7 +98,7 @@ pub async fn main() -> anyhow::Result<()> {
         }
         Err(e) => {
             eprintln!("Error: {e:?}");
-            Err(anyhow!(e.to_string()))
+            eyre::bail!(e);
         }
     }
 }

--- a/crates/prover-alloy/Cargo.toml
+++ b/crates/prover-alloy/Cargo.toml
@@ -15,9 +15,9 @@ agglayer-evm-client.workspace = true
 
 alloy.workspace = true
 async-trait.workspace = true
-anyhow.workspace = true
 derive_more.workspace = true
 educe.workspace = true
+eyre.workspace = true
 ff.workspace = true
 mockall = { workspace = true, optional = true }
 serde.workspace = true

--- a/crates/prover-alloy/src/lib.rs
+++ b/crates/prover-alloy/src/lib.rs
@@ -34,7 +34,7 @@ pub fn build_alloy_fill_provider(
     rpc_url: &url::Url,
     backoff: u64,
     max_retries: u32,
-) -> Result<AlloyFillProvider, anyhow::Error> {
+) -> eyre::Result<AlloyFillProvider> {
     let retry_policy = RetryBackoffLayer::new(max_retries, backoff, 5);
     let reqwest_client = reqwest::ClientBuilder::new()
         .pool_max_idle_per_host(HTTP_CLIENT_MAX_IDLE_CONNECTIONS_PER_HOST)
@@ -60,11 +60,7 @@ pub struct AlloyProvider {
 }
 
 impl AlloyProvider {
-    pub fn new(
-        rpc_url: &url::Url,
-        backoff: u64,
-        max_retries: u32,
-    ) -> Result<AlloyProvider, anyhow::Error> {
+    pub fn new(rpc_url: &url::Url, backoff: u64, max_retries: u32) -> eyre::Result<AlloyProvider> {
         let retry_policy = RetryBackoffLayer::new(max_retries, backoff, 5);
         let reqwest_client = reqwest::ClientBuilder::new()
             .pool_max_idle_per_host(HTTP_CLIENT_MAX_IDLE_CONNECTIONS_PER_HOST)

--- a/crates/prover-engine/src/lib.rs
+++ b/crates/prover-engine/src/lib.rs
@@ -12,8 +12,6 @@ use tonic::{
 use tower::{Service, ServiceExt};
 use tracing::{debug, info};
 
-pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
-
 pub struct ProverEngine {
     rpc_server: axum::Router,
     rpc_runtime: Option<Runtime>,
@@ -77,7 +75,7 @@ impl ProverEngine {
             + Send
             + 'static,
         S::Future: Send + 'static,
-        S::Error: Into<BoxError> + Send,
+        S::Error: Into<eyre::Report> + Send,
     {
         self.rpc_server = add_rpc_service(self.rpc_server, rpc_service);
         self.healthy_service.push(S::NAME);
@@ -231,7 +229,7 @@ where
         + Send
         + 'static,
     S::Future: Send + 'static,
-    S::Error: Into<BoxError> + Send,
+    S::Error: Into<eyre::Report> + Send,
 {
     rpc_server.route_service(
         &format!("/{}/{{*rest}}", S::NAME),


### PR DESCRIPTION
Second part of https://github.com/agglayer/security/issues/80

BREAKING-CHANGE: Error types have been migrated to eyre in the API. No expected user-facing change unless the binary enables color-eyre.