### PR TITLE
refactor: use vkey hashing utilities in agglayer-primitives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,6 +226,7 @@ version = "0.1.0"
 dependencies = [
  "aggchain-proof-types",
  "agglayer-interop",
+ "agglayer-primitives",
  "alloy-primitives 1.3.1",
  "eyre",
  "pbjson",

--- a/crates/aggchain-proof-builder/src/error.rs
+++ b/crates/aggchain-proof-builder/src/error.rs
@@ -1,6 +1,6 @@
 use aggchain_proof_core::full_execution_proof::AggregationProofPublicValues;
-use aggkit_prover_types::vkey_hash::VKeyHash;
 use agglayer_interop::types::bincode;
+use agglayer_primitives::vkey_hash::VKeyHash;
 
 use crate::WitnessGeneration;
 

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -25,7 +25,7 @@ use aggchain_proof_core::{
     proof::{AggchainProofWitness, IMPORTED_BRIDGE_EXIT_COMMITMENT_VERSION},
 };
 use aggchain_proof_types::AggchainProofInputs;
-use aggkit_prover_types::vkey_hash::VKeyHash;
+use aggkit_prover_types::vkey_hash::{VKeyHash, Sp1VKeyHash};
 use agglayer_interop::types::{
     bincode, GlobalIndexWithLeafHash, ImportedBridgeExitCommitmentValues,
 };

--- a/crates/aggchain-proof-builder/src/lib.rs
+++ b/crates/aggchain-proof-builder/src/lib.rs
@@ -25,7 +25,7 @@ use aggchain_proof_core::{
     proof::{AggchainProofWitness, IMPORTED_BRIDGE_EXIT_COMMITMENT_VERSION},
 };
 use aggchain_proof_types::AggchainProofInputs;
-use aggkit_prover_types::vkey_hash::{VKeyHash, Sp1VKeyHash};
+use aggkit_prover_types::vkey_hash::{Sp1VKeyHash, VKeyHash};
 use agglayer_interop::types::{
     bincode, GlobalIndexWithLeafHash, ImportedBridgeExitCommitmentValues,
 };

--- a/crates/aggkit-prover-types/Cargo.toml
+++ b/crates/aggkit-prover-types/Cargo.toml
@@ -23,6 +23,7 @@ sp1-sdk = { workspace = true, optional = true }
 
 aggchain-proof-types.workspace = true
 agglayer-interop = { workspace = true, features = ["grpc-compat"] }
+agglayer-primitives.workspace = true
 pbjson.workspace = true
 prover-elf-utils = { workspace = true, optional = true }
 

--- a/crates/aggkit-prover-types/src/lib.rs
+++ b/crates/aggkit-prover-types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod conversion;
 pub mod error;
 #[cfg(feature = "sp1")]
 pub mod vkey;
+#[cfg(feature = "sp1")]
 pub mod vkey_hash;
 
 pub use agglayer_interop::types::{bincode, Digest};

--- a/crates/aggkit-prover-types/src/vkey_hash.rs
+++ b/crates/aggkit-prover-types/src/vkey_hash.rs
@@ -1,106 +1,12 @@
 pub use aggchain_proof_types::HashU32;
-use alloy_primitives::B256;
-use serde::{Deserialize, Serialize};
+pub use agglayer_primitives::vkey_hash::VKeyHash;
 
-/// SP1 verifying key hash.
-#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-#[serde(from = "B256", into = "B256")]
-pub struct VKeyHash(HashU32);
+pub trait Sp1VKeyHash {
+    fn from_vkey<K: sp1_sdk::HashableKey>(vkey: &K) -> Self;
+}
 
-impl VKeyHash {
-    pub const fn from_hash_u32(hash: HashU32) -> Self {
-        Self(hash)
-    }
-
-    pub const fn from_bytes(bytes: B256) -> Self {
-        let bytes = bytes.0;
-        let mut hash_u32: HashU32 = [0; 8];
-
-        let mut w = 0_usize;
-        while w < 8 {
-            let b0 = bytes[4 * w];
-            let b1 = bytes[4 * w + 1];
-            let b2 = bytes[4 * w + 2];
-            let b3 = bytes[4 * w + 3];
-            hash_u32[w] = u32::from_be_bytes([b0, b1, b2, b3]);
-            w += 1;
-        }
-
-        Self(hash_u32)
-    }
-
-    #[cfg(feature = "sp1")]
-    pub fn from_vkey<K: sp1_sdk::HashableKey>(vkey: &K) -> Self {
+impl Sp1VKeyHash for VKeyHash {
+    fn from_vkey<K: sp1_sdk::HashableKey>(vkey: &K) -> Self {
         Self::from_hash_u32(vkey.hash_u32())
-    }
-
-    pub const fn to_bytes(&self) -> B256 {
-        let mut bytes = [0_u8; 32];
-
-        let mut w = 0_usize;
-        while w < 8 {
-            let [b0, b1, b2, b3] = self.0[w].to_be_bytes();
-            bytes[4 * w] = b0;
-            bytes[4 * w + 1] = b1;
-            bytes[4 * w + 2] = b2;
-            bytes[4 * w + 3] = b3;
-            w += 1;
-        }
-
-        B256::new(bytes)
-    }
-
-    pub const fn to_hash_u32(&self) -> HashU32 {
-        self.0
-    }
-}
-
-impl From<B256> for VKeyHash {
-    fn from(bytes: B256) -> Self {
-        Self::from_bytes(bytes)
-    }
-}
-
-impl From<VKeyHash> for B256 {
-    fn from(hash: VKeyHash) -> Self {
-        hash.to_bytes()
-    }
-}
-
-impl std::str::FromStr for VKeyHash {
-    type Err = <B256 as std::str::FromStr>::Err;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        s.parse().map(Self::from_bytes)
-    }
-}
-
-impl std::fmt::Debug for VKeyHash {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.to_bytes().fmt(f)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use alloy_primitives::b256;
-
-    use super::*;
-
-    #[test]
-    fn constructors_consistently_be() {
-        let from_hash_u32 = VKeyHash::from_hash_u32([
-            0x00010203, 0x04050607, 0x08090a0b, 0x0c0d0e0f, 0x10111213, 0x14151617, 0x18191a1b,
-            0x1c1d1e1f,
-        ]);
-
-        let from_hex = VKeyHash::from_bytes(b256!(
-            "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
-        ));
-
-        assert_eq!(from_hash_u32, from_hex);
-
-        let roundtrip = VKeyHash::from_bytes(from_hash_u32.to_bytes());
-        assert_eq!(from_hash_u32, roundtrip);
     }
 }

--- a/crates/proposer-elfs/src/lib.rs
+++ b/crates/proposer-elfs/src/lib.rs
@@ -1,6 +1,6 @@
 pub use aggkit_prover_types::{
     vkey::LazyVerifyingKey,
-    vkey_hash::{HashU32, VKeyHash},
+    vkey_hash::{HashU32, VKeyHash, Sp1VKeyHash},
 };
 
 mod vkeys_raw {

--- a/crates/proposer-elfs/src/lib.rs
+++ b/crates/proposer-elfs/src/lib.rs
@@ -1,6 +1,6 @@
 pub use aggkit_prover_types::{
     vkey::LazyVerifyingKey,
-    vkey_hash::{HashU32, VKeyHash, Sp1VKeyHash},
+    vkey_hash::{HashU32, Sp1VKeyHash, VKeyHash},
 };
 
 mod vkeys_raw {


### PR DESCRIPTION
Ensure that we use vkey hashing utilities from agglayer primitives, and remove vkey hashing operations from this repo.

Partial agglayer/interop#101