### PR TITLE
chore: fix build script to always run from repo root

### DIFF
--- a/scripts/build-docker-images
+++ b/scripts/build-docker-images
@@ -1,4 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
 echo "Building the docker images. Note this script should be run from the repository root."
-docker build -t aggkit-prover:local .
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$SCRIPT_DIR/.."
+docker build -t aggkit-prover:local "$REPO_ROOT"


### PR DESCRIPTION
switched the shebang to bash, added `SCRIPT_DIR` + `REPO_ROOT`, and updated `docker build` to always use the repo root.
now the script works no matter where you run it from.
