### PR TITLE
fix: grpc max decoding/encoding size

### DIFF
--- a/crates/agglayer-prover-config/src/lib.rs
+++ b/crates/agglayer-prover-config/src/lib.rs
@@ -14,7 +14,8 @@ pub use crate::{shutdown::ShutdownConfig, telemetry::TelemetryConfig};
 pub mod shutdown;
 pub(crate) mod telemetry;
 
-pub(crate) const DEFAULT_IP: std::net::Ipv4Addr = std::net::Ipv4Addr::new(0, 0, 0, 0);
+pub(crate) const DEFAULT_IP: Ipv4Addr = Ipv4Addr::new(0, 0, 0, 0);
+pub const DEFAULT_GRPC_MESSAGE_SIZE: usize = 64 * 1024 * 1024; // 64MB
 
 /// The Agglayer Prover configuration.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -125,13 +126,13 @@ pub struct ClientProverConfig {
 }
 
 const fn default_max_decoding_message_size() -> usize {
-    4 * 1024 * 1024
+    DEFAULT_GRPC_MESSAGE_SIZE
 }
 fn same_as_default_max_decoding_message_size(value: &usize) -> bool {
     *value == default_max_decoding_message_size()
 }
 const fn default_max_encoding_message_size() -> usize {
-    4 * 1024 * 1024
+    DEFAULT_GRPC_MESSAGE_SIZE
 }
 fn same_as_default_max_encoding_message_size(value: &usize) -> bool {
     *value == default_max_encoding_message_size()

--- a/crates/agglayer-prover/src/fake.rs
+++ b/crates/agglayer-prover/src/fake.rs
@@ -1,5 +1,6 @@
 use std::{net::SocketAddr, sync::Arc};
 
+use agglayer_prover_config::DEFAULT_GRPC_MESSAGE_SIZE;
 use agglayer_prover_types::{
     bincode,
     v1::{
@@ -41,6 +42,8 @@ impl FakeProver {
         cancellation_token: tokio_util::sync::CancellationToken,
     ) -> Result<tokio::task::JoinHandle<Result<(), tonic::transport::Error>>, ()> {
         let svc = PessimisticProofServiceServer::new(fake_prover)
+            .max_decoding_message_size(DEFAULT_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(DEFAULT_GRPC_MESSAGE_SIZE)
             .send_compressed(CompressionEncoding::Zstd)
             .accept_compressed(CompressionEncoding::Zstd);
 


### PR DESCRIPTION
Fix grpc config.
 
Switching to new tonic version, communication was breaking due to limited message size. 