### PR TITLE
fix: map SP1VerificationError::Other to ProofVerificationError::Other

### DIFF
--- a/crates/prover-executor/src/error.rs
+++ b/crates/prover-executor/src/error.rs
@@ -52,7 +52,7 @@ impl From<SP1VerificationError> for ProofVerificationError {
             SP1VerificationError::InvalidPublicValues => {
                 ProofVerificationError::InvalidPublicValues
             }
-            SP1VerificationError::Other(error) => ProofVerificationError::Core(error.to_string()),
+            SP1VerificationError::Other(error) => ProofVerificationError::Other(error.to_string()),
         }
     }
 }


### PR DESCRIPTION
`SP1VerificationError::Other` is documented as a generic “proof is invalid” error, not a core machine verification failure. Previously mapped it into `ProofVerificationError::Core`, which misclassified these errors and left the Other variant unused. This change maps `SP1VerificationError::Other` to `ProofVerificationError::Other` so logs and any downstream handling see the correct error category.